### PR TITLE
fix(windows): allow tauri.localhost in navigation guard + Windows build docs

### DIFF
--- a/docs/guides/development-setup.md
+++ b/docs/guides/development-setup.md
@@ -7,6 +7,8 @@
 - **Tauri CLI** (`cargo install tauri-cli`)
 - **git** and **gh** (GitHub CLI) for git/GitHub features
 
+> **Windows users:** See the [Windows-specific prerequisites](#windows-prerequisites) section below before proceeding.
+
 ## Install Dependencies
 
 ```bash
@@ -41,8 +43,13 @@ npm run tauri build
 
 Produces platform-specific installers:
 - macOS: `.dmg` and `.app`
-- Windows: `.msi` and `.exe`
+- Windows: `.nsis` (`.exe` setup installer)
 - Linux: `.deb` and `.AppImage`
+
+> **Note:** The `.msi` bundle may fail on Windows due to WiX tooling issues. Use `--bundles nsis` to produce a working `.exe` installer:
+> ```bash
+> cargo tauri build --bundles nsis
+> ```
 
 ## Testing
 
@@ -97,3 +104,88 @@ make test     # Run tests
 make lint     # Run linter
 make clean    # Clean build artifacts
 ```
+
+---
+
+## Windows Prerequisites
+
+Building on Windows requires a few extra tools beyond the standard prerequisites. Install them in this order.
+
+### 1. Visual Studio Build Tools (C++ compiler)
+
+Download and install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and select the **"Desktop development with C++"** workload. VS Build Tools 2019 or later is fine.
+
+Or via winget:
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools
+```
+
+### 2. Rust
+
+```powershell
+winget install Rustlang.Rustup
+```
+
+Restart your terminal after installation, then verify:
+```powershell
+rustc --version
+cargo --version
+```
+
+### 3. Node.js
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+### 4. CMake
+
+Required to compile `whisper-rs` (the on-device dictation library).
+
+```powershell
+winget install Kitware.CMake
+```
+
+### 5. LLVM 18 (libclang — required for whisper-rs bindings)
+
+`whisper-rs` uses `bindgen` to generate Rust bindings for `whisper.cpp`, which requires `libclang`. **Use LLVM 18** — LLVM 19+ produces broken bindings for this crate on Windows.
+
+Download the LLVM 18 installer from [GitHub releases](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8) (`LLVM-18.1.8-win64.exe`) and install it. Then set the environment variable so `bindgen` can find it:
+
+```powershell
+# Add to your PowerShell profile or set permanently in System Environment Variables
+$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"
+```
+
+> If you have LLVM 22+ installed (e.g. from winget), install LLVM 18 to a separate directory and point `LIBCLANG_PATH` there instead.
+
+### 6. Tauri CLI
+
+```powershell
+cargo install tauri-cli --version "^2"
+```
+
+### Full Windows Build Command
+
+Always set `LIBCLANG_PATH` before building:
+
+```powershell
+$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"   # adjust path if LLVM 18 is elsewhere
+cargo tauri build --bundles nsis
+```
+
+The installer will be at:
+```
+src-tauri\target\release\bundle\nsis\TUICommander_0.x.x_x64-setup.exe
+```
+
+### Windows Known Issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `whisper-rs-sys` build fails with "couldn't find libclang" | LLVM not installed or `LIBCLANG_PATH` not set | Install LLVM 18 and set `LIBCLANG_PATH` |
+| `whisper-rs-sys` compile error: `attempt to compute 1_usize - 296_usize` | LLVM 19+ generates broken bindings for this crate | Use LLVM 18 specifically |
+| WiX `.msi` bundle fails | WiX `light.exe` tooling issue | Use `--bundles nsis` instead |
+| App window opens but shows a **black screen** | Navigation guard in `lib.rs` blocked `http://tauri.localhost/` (Windows' internal Tauri URL) | Fixed in current code — `tauri.localhost` is explicitly allowed |
+| `Update check failed: windows-x86_64-nsis not found` | Custom local build isn't listed in official release manifest | Harmless — auto-update simply won't trigger |
+| `Lazygit not found` | Lazygit is not installed | Optional: `winget install jesseduffield.lazygit` |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -644,17 +644,15 @@ pub fn run() {
         .plugin(
             tauri::plugin::Builder::<tauri::Wry, ()>::new("navigation-guard")
                 .on_navigation(|_webview, url| {
-                    // Allow internal navigation (tauri://, localhost in dev)
+                    // Allow internal navigation (tauri://, localhost in dev,
+                    // and http://tauri.localhost/ on Windows production builds)
                     let scheme = url.scheme();
                     if scheme == "tauri" || scheme == "asset" || scheme == "plugin" {
                         return true;
                     }
-                    #[cfg(dev)]
-                    {
-                        let host = url.host_str().unwrap_or("");
-                        if host == "localhost" || host == "127.0.0.1" {
-                            return true;
-                        }
+                    let host = url.host_str().unwrap_or("");
+                    if host == "tauri.localhost" || host == "localhost" || host == "127.0.0.1" {
+                        return true;
                     }
                     // External URL — open in system browser, block webview navigation
                     if scheme == "http" || scheme == "https" {


### PR DESCRIPTION
## Problem

On Windows, Tauri v2 serves the bundled frontend from `http://tauri.localhost/` (HTTP scheme), not the `tauri://` scheme that macOS uses. The navigation guard in `lib.rs` only allowed:

- `tauri://` scheme
- `localhost` / `127.0.0.1` inside a `#[cfg(dev)]` block (dev builds only)

This caused the initial page load on **Windows production builds** to be intercepted by the `http`/`https` branch, opened in the system browser, and the app window to stay **permanently black**.

## Fix

Allow the `tauri.localhost` hostname unconditionally:

`ust
let host = url.host_str().unwrap_or("");
if host == "tauri.localhost" || host == "localhost" || host == "127.0.0.1" {
    return true;
}
`

## Docs

Added a full **Windows build guide** to `docs/guides/development-setup.md`:

- Required tools in order: VS Build Tools, Rust, Node.js, CMake, LLVM 18
- **LLVM 18 required**: LLVM 19+ generates broken bindings for `whisper-rs-sys` on Windows (`1_usize - 296_usize` overflow compile error in bindgen output)
- WiX `.msi` bundle workaround: use `--bundles nsis`
- Known issues table covering all Windows-specific build and runtime problems

## Tested on

Windows 11, WebView2 v145, Rust 1.94, LLVM 18.1.8, CMake 4.2.3
