### PR TITLE
fix(terminal): remove input suppression that caused UI freeze

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -677,27 +677,6 @@ export const Terminal: Component<TerminalProps> = (props) => {
         }
       }
 
-      // Suppress printable keys and arrows when no interactive program is reading input.
-      // Prevents ugly raw echo during e.g. cargo build or before shell is ready.
-      // Allow input when:
-      //  - shell is idle (prompt is active, readline handles input)
-      //  - alternate screen (vim, htop, Ink/Claude Code)
-      //  - agent awaits input (question prompt)
-      //  - kitty keyboard active (app explicitly requested key protocol = reads input)
-      // Control keys (Ctrl+C/Z/D) always pass through to allow killing commands.
-      {
-        const shell = terminalsStore.get(props.id);
-        const noReader = (shell?.shellState === "busy" || shell?.shellState === null)
-          && !shell?.awaitingInput
-          && terminal!.buffer.active.type === "normal"
-          && !(kittyFlags & 1);
-        if (noReader && event.type === "keydown") {
-          const isArrow = ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(event.key);
-          const isPrintable = !event.ctrlKey && !event.metaKey && !event.altKey && event.key.length === 1;
-          if (isArrow || isPrintable) return false;
-        }
-      }
-
       // Kitty keyboard protocol: encode special keys when flag 1 (disambiguate) is active
       if (event.type === "keydown" && (kittyFlags & 1)) {
         const seq = kittySequenceForKey(event.key, event.shiftKey, event.altKey, event.ctrlKey, event.metaKey);


### PR DESCRIPTION
## Summary
- Removes the key suppression block from `attachCustomKeyEventHandler` that was causing complete UI unresponsiveness (typing, arrow keys, scroll)
- Root cause: every keystroke produces shell echo → `shellState="busy"` → next keystroke blocked for 500ms until idle timer fires — a vicious cycle
- The suppression (commits 0ddb36d8, 78c707e4) was meant to prevent `^[[A` echo during non-interactive commands, but `shellState` cannot distinguish shell echo from command output, making the approach fundamentally broken

## Test plan
- [x] Verified responsive typing at shell prompt
- [x] Verified arrow keys work instantly (history navigation, cursor movement)
- [x] Verified scroll is responsive
- [x] Binary search across 24 commits confirmed this block as the sole cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)