### PR TITLE
feat(ui): add color picker for group color selection

### DIFF
--- a/src/__tests__/components/SettingsPanel/GroupsTab.test.tsx
+++ b/src/__tests__/components/SettingsPanel/GroupsTab.test.tsx
@@ -111,8 +111,8 @@ describe("AppearanceTab — Repository Groups", () => {
     );
     const { container } = render(() => <AppearanceTab />);
     const swatches = container.querySelectorAll(".colorSwatch");
-    // 8 presets + 1 clear option
-    expect(swatches.length).toBeGreaterThanOrEqual(5);
+    // 8 presets + 1 custom + 1 clear
+    expect(swatches.length).toBe(10);
   });
 
   it("clicking color swatch calls setGroupColor", () => {

--- a/src/__tests__/components/shared/ColorPickerDialog.test.tsx
+++ b/src/__tests__/components/shared/ColorPickerDialog.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import "../../mocks/tauri";
+
+vi.mock("../../../stores/settings", () => ({
+  settingsStore: { state: {} },
+}));
+
+vi.mock("../../../stores/ui", () => ({
+  uiStore: { state: {} },
+}));
+
+vi.mock("../../../stores/repositories", () => ({
+  repositoriesStore: { state: { groups: {}, groupOrder: [] } },
+}));
+
+vi.mock("../../../themes", () => ({
+  THEME_NAMES: {},
+}));
+
+import { ColorPickerDialog } from "../../../components/shared/ColorPickerDialog";
+import { PRESET_COLORS } from "../../../components/SettingsPanel/tabs/AppearanceTab";
+
+describe("ColorPickerDialog", () => {
+  let onClose: () => void;
+  let onConfirm: (color: string) => void;
+
+  beforeEach(() => {
+    onClose = vi.fn();
+    onConfirm = vi.fn();
+  });
+
+  it("does not render when visible is false", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={false}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    expect(container.querySelector(".overlay")).toBeNull();
+  });
+
+  it("renders overlay and popover when visible", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    expect(container.querySelector(".overlay")).not.toBeNull();
+    expect(container.querySelector(".popover")).not.toBeNull();
+  });
+
+  it("renders title in header", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const header = container.querySelector("h4");
+    expect(header?.textContent).toBe("Group Color");
+  });
+
+  it("contains color swatches", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const swatches = container.querySelectorAll(".colorSwatch");
+    expect(swatches.length).toBe(10);
+  });
+
+  it("clicking a preset swatch calls onConfirm and onClose", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const firstSwatch = container.querySelector(".colorSwatch")!;
+    fireEvent.click(firstSwatch);
+    expect(onConfirm).toHaveBeenCalledWith(PRESET_COLORS[0].hex);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clicking clear calls onConfirm with empty string and closes", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor="#4A9EFF"
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const clearBtn = container.querySelector(".colorSwatchClear")!;
+    fireEvent.click(clearBtn);
+    expect(onConfirm).toHaveBeenCalledWith("");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clicking overlay backdrop calls onClose", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const overlay = container.querySelector(".overlay")!;
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("Escape key calls onClose", () => {
+    render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("Cancel button calls onClose", () => {
+    const { container } = render(() => (
+      <ColorPickerDialog
+        visible={true}
+        title="Group Color"
+        currentColor=""
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    ));
+    const cancelBtn = container.querySelector(".cancelBtn")!;
+    fireEvent.click(cancelBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/shared/ColorSwatchPicker.test.tsx
+++ b/src/__tests__/components/shared/ColorSwatchPicker.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import "../../mocks/tauri";
+
+vi.mock("../../../stores/settings", () => ({
+  settingsStore: { state: {} },
+}));
+
+vi.mock("../../../stores/ui", () => ({
+  uiStore: { state: {} },
+}));
+
+vi.mock("../../../stores/repositories", () => ({
+  repositoriesStore: { state: { groups: {}, groupOrder: [] } },
+}));
+
+vi.mock("../../../themes", () => ({
+  THEME_NAMES: {},
+}));
+
+import { ColorSwatchPicker } from "../../../components/shared/ColorSwatchPicker";
+import { PRESET_COLORS } from "../../../components/SettingsPanel/tabs/AppearanceTab";
+
+describe("ColorSwatchPicker", () => {
+  let onChange: (color: string) => void;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it("renders 8 preset swatches + 1 custom + 1 clear", () => {
+    const { container } = render(() => <ColorSwatchPicker color="" onChange={onChange} />);
+    const swatches = container.querySelectorAll(".colorSwatch");
+    // 8 presets + 1 custom (label) + 1 clear
+    expect(swatches.length).toBe(10);
+  });
+
+  it("clicking a preset swatch calls onChange with its hex", () => {
+    const { container } = render(() => <ColorSwatchPicker color="" onChange={onChange} />);
+    const firstSwatch = container.querySelector(".colorSwatch")!;
+    fireEvent.click(firstSwatch);
+    expect(onChange).toHaveBeenCalledWith(PRESET_COLORS[0].hex);
+  });
+
+  it("clicking clear calls onChange with empty string", () => {
+    const { container } = render(() => <ColorSwatchPicker color="#4A9EFF" onChange={onChange} />);
+    const clearBtn = container.querySelector(".colorSwatchClear")!;
+    fireEvent.click(clearBtn);
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("marks preset swatch as active when color matches", () => {
+    const { container } = render(() => <ColorSwatchPicker color="#4A9EFF" onChange={onChange} />);
+    const firstSwatch = container.querySelector(".colorSwatch")!;
+    expect(firstSwatch.classList.contains("active")).toBe(true);
+  });
+
+  it("marks clear as active when no color set", () => {
+    const { container } = render(() => <ColorSwatchPicker color="" onChange={onChange} />);
+    const clearBtn = container.querySelector(".colorSwatchClear")!;
+    expect(clearBtn.classList.contains("active")).toBe(true);
+  });
+
+  it("marks custom swatch as active for non-preset color", () => {
+    const { container } = render(() => <ColorSwatchPicker color="#123456" onChange={onChange} />);
+    const customSwatch = container.querySelector(".colorSwatchCustom")!;
+    expect(customSwatch.classList.contains("active")).toBe(true);
+  });
+
+  it("custom color input fires onChange with picked value", () => {
+    const { container } = render(() => <ColorSwatchPicker color="" onChange={onChange} />);
+    const colorInput = container.querySelector("input[type='color']")! as HTMLInputElement;
+    fireEvent.input(colorInput, { target: { value: "#abcdef" } });
+    expect(onChange).toHaveBeenCalledWith("#abcdef");
+  });
+});

--- a/src/components/SettingsPanel/tabs/AppearanceTab.tsx
+++ b/src/components/SettingsPanel/tabs/AppearanceTab.tsx
@@ -5,8 +5,8 @@ import { repositoriesStore } from "../../../stores/repositories";
 import type { RepoGroup } from "../../../stores/repositories";
 import type { FontType } from "../../../stores/settings";
 import { THEME_NAMES } from "../../../themes";
+import { ColorSwatchPicker } from "../../shared/ColorSwatchPicker";
 import { t } from "../../../i18n";
-import { cx } from "../../../utils";
 import s from "../Settings.module.css";
 
 /** Preset colors for groups and sidebar */
@@ -89,25 +89,10 @@ const GroupSettingsItem: Component<{
       <Show when={nameError()}>
         <div class={s.groupNameError}>{nameError()}</div>
       </Show>
-      <div class={s.groupColorPicker}>
-        <For each={PRESET_COLORS}>
-          {(preset) => (
-            <button
-              class={cx(s.colorSwatch, props.group.color === preset.hex && s.active)}
-              style={{ background: preset.hex }}
-              onClick={() => repositoriesStore.setGroupColor(props.group.id, preset.hex)}
-              title={preset.name}
-            />
-          )}
-        </For>
-        <button
-          class={cx(s.colorSwatch, s.colorSwatchClear, !props.group.color && s.active)}
-          onClick={() => repositoriesStore.setGroupColor(props.group.id, "")}
-          title={t("groups.btn.noColor", "No color")}
-        >
-          ×
-        </button>
-      </div>
+      <ColorSwatchPicker
+        color={props.group.color}
+        onChange={(c) => repositoriesStore.setGroupColor(props.group.id, c)}
+      />
     </div>
   );
 };

--- a/src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx
+++ b/src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx
@@ -1,10 +1,9 @@
 import { Component, For, Show } from "solid-js";
 import type { RepoSettings } from "../../../stores/repoSettings";
 import type { RepoDefaults, WorktreeStorage, OrphanCleanup, MergeStrategy, WorktreeAfterMerge, AutoDeleteOnPrClose } from "../../../stores/repoDefaults";
-import { PRESET_COLORS } from "./AppearanceTab";
+import { ColorSwatchPicker } from "../../shared/ColorSwatchPicker";
 import { isMacOS } from "../../../platform";
 import { t } from "../../../i18n";
-import { cx } from "../../../utils";
 import s from "../Settings.module.css";
 
 export interface RepoTabProps {
@@ -52,43 +51,10 @@ export const RepoWorktreeTab: Component<RepoTabProps> = (props) => {
 
       <div class={s.group}>
         <label>{t("repoWorktree.label.sidebarColor", "Sidebar Color")}</label>
-        <div class={s.groupColorPicker}>
-          <For each={PRESET_COLORS}>
-            {(preset) => (
-              <button
-                class={cx(s.colorSwatch, props.settings.color === preset.hex && s.active)}
-                style={{ background: preset.hex }}
-                onClick={() => props.onUpdate("color", preset.hex)}
-                title={preset.name}
-              />
-            )}
-          </For>
-          <label
-            class={cx(s.colorSwatch, s.colorSwatchCustom, props.settings.color && !PRESET_COLORS.some((p) => p.hex === props.settings.color) && s.active)}
-            style={{
-              background: props.settings.color && !PRESET_COLORS.some((p) => p.hex === props.settings.color)
-                ? props.settings.color
-                : "var(--bg-tertiary)",
-            }}
-            title={t("repoWorktree.btn.customColor", "Custom color")}
-          >
-            <input
-              type="color"
-              value={props.settings.color || "#999999"}
-              onInput={(e) => props.onUpdate("color", e.currentTarget.value)}
-            />
-            <Show when={!props.settings.color || PRESET_COLORS.some((p) => p.hex === props.settings.color)}>
-              <span class={s.colorSwatchLabel}>⋯</span>
-            </Show>
-          </label>
-          <button
-            class={cx(s.colorSwatch, s.colorSwatchClear, !props.settings.color && s.active)}
-            onClick={() => props.onUpdate("color", "")}
-            title={t("repoWorktree.btn.defaultColor", "Use default color")}
-          >
-            ×
-          </button>
-        </div>
+        <ColorSwatchPicker
+          color={props.settings.color ?? ""}
+          onChange={(c) => props.onUpdate("color", c)}
+        />
         <p class={s.hint}>{t("repoWorktree.hint.sidebarColor", "Color-code this repo in the sidebar")}</p>
       </div>
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import type { ContextMenuItem } from "../ContextMenu";
 import { PrDetailPopover } from "../PrDetailPopover/PrDetailPopover";
 import { ParkedReposPopover } from "./ParkedReposPopover";
 import { PromptDialog } from "../PromptDialog";
+import { ColorPickerDialog } from "../shared/ColorPickerDialog";
 import { t } from "../../i18n";
 import { RepoSection } from "./RepoSection";
 import { GroupSection } from "./GroupSection";
@@ -432,11 +433,10 @@ export const Sidebar: Component<SidebarProps> = (props) => {
       />
 
       {/* Group color dialog */}
-      <PromptDialog
+      <ColorPickerDialog
         visible={colorGroupTarget() !== null}
         title="Group Color"
-        placeholder="#ff6b6b"
-        confirmLabel="Apply"
+        currentColor={colorGroupTarget() ? repositoriesStore.state.groups[colorGroupTarget()!]?.color ?? "" : ""}
         onClose={() => setColorGroupTarget(null)}
         onConfirm={(color) => {
           const groupId = colorGroupTarget();

--- a/src/components/shared/ColorPickerDialog.tsx
+++ b/src/components/shared/ColorPickerDialog.tsx
@@ -1,0 +1,53 @@
+import { Component, Show, createEffect, onCleanup } from "solid-js";
+import { ColorSwatchPicker } from "./ColorSwatchPicker";
+import { t } from "../../i18n";
+import d from "./dialog.module.css";
+
+export interface ColorPickerDialogProps {
+  visible: boolean;
+  title: string;
+  currentColor: string;
+  onClose: () => void;
+  onConfirm: (color: string) => void;
+}
+
+export const ColorPickerDialog: Component<ColorPickerDialogProps> = (props) => {
+  createEffect(() => {
+    if (!props.visible) return;
+
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        props.onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeydown);
+    onCleanup(() => document.removeEventListener("keydown", handleKeydown));
+  });
+
+  const handleChange = (color: string) => {
+    props.onConfirm(color);
+    props.onClose();
+  };
+
+  return (
+    <Show when={props.visible}>
+      <div class={d.overlay} onClick={props.onClose}>
+        <div class={d.popover} onClick={(e) => e.stopPropagation()}>
+          <div class={d.header}>
+            <h4>{props.title}</h4>
+          </div>
+          <div class={d.body}>
+            <ColorSwatchPicker color={props.currentColor} onChange={handleChange} />
+          </div>
+          <div class={d.actions}>
+            <button class={d.cancelBtn} onClick={props.onClose}>
+              {t("colorPickerDialog.cancel", "Cancel")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/shared/ColorSwatchPicker.tsx
+++ b/src/components/shared/ColorSwatchPicker.tsx
@@ -1,0 +1,53 @@
+import { Component, For, Show } from "solid-js";
+import { PRESET_COLORS } from "../SettingsPanel/tabs/AppearanceTab";
+import { t } from "../../i18n";
+import { cx } from "../../utils";
+import s from "../SettingsPanel/Settings.module.css";
+
+export interface ColorSwatchPickerProps {
+  color: string;
+  onChange: (color: string) => void;
+}
+
+export const ColorSwatchPicker: Component<ColorSwatchPickerProps> = (props) => {
+  const isCustomColor = () =>
+    props.color && !PRESET_COLORS.some((p) => p.hex === props.color);
+
+  return (
+    <div class={s.groupColorPicker}>
+      <For each={PRESET_COLORS}>
+        {(preset) => (
+          <button
+            class={cx(s.colorSwatch, props.color === preset.hex && s.active)}
+            style={{ background: preset.hex }}
+            onClick={() => props.onChange(preset.hex)}
+            title={preset.name}
+          />
+        )}
+      </For>
+      <label
+        class={cx(s.colorSwatch, s.colorSwatchCustom, isCustomColor() && s.active)}
+        style={{
+          background: isCustomColor() ? props.color : "var(--bg-tertiary)",
+        }}
+        title={t("groups.btn.customColor", "Custom color")}
+      >
+        <input
+          type="color"
+          value={props.color || "#999999"}
+          onInput={(e) => props.onChange(e.currentTarget.value)}
+        />
+        <Show when={!isCustomColor()}>
+          <span class={s.colorSwatchLabel}>&#x22EF;</span>
+        </Show>
+      </label>
+      <button
+        class={cx(s.colorSwatch, s.colorSwatchClear, !props.color && s.active)}
+        onClick={() => props.onChange("")}
+        title={t("groups.btn.noColor", "No color")}
+      >
+        &times;
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- Replace the raw text `PromptDialog` in the sidebar's "Change Color" context menu with a visual **ColorPickerDialog** showing preset swatches, a native browser color picker, and a clear button
- Extract a shared **ColorSwatchPicker** component reused by `AppearanceTab`, `RepoWorktreeTab`, and the new `ColorPickerDialog`
- Add custom color support (via native `<input type="color">`) to the Settings group color picker, which previously only had 8 presets

## Changes

| File | Change |
|------|--------|
| `src/components/shared/ColorSwatchPicker.tsx` | **New** — shared swatch row (8 presets + native color picker + clear) |
| `src/components/shared/ColorPickerDialog.tsx` | **New** — dialog wrapping ColorSwatchPicker for sidebar use |
| `src/components/SettingsPanel/tabs/AppearanceTab.tsx` | Use `ColorSwatchPicker` (removes inline swatch loop) |
| `src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx` | Use `ColorSwatchPicker` (removes inline swatch loop) |
| `src/components/Sidebar/Sidebar.tsx` | Replace `PromptDialog` with `ColorPickerDialog` |
| `src/__tests__/components/shared/ColorSwatchPicker.test.tsx` | **New** — 7 tests |
| `src/__tests__/components/shared/ColorPickerDialog.test.tsx` | **New** — 9 tests |
| `src/__tests__/components/SettingsPanel/GroupsTab.test.tsx` | Update swatch count expectation |

## Test plan

- [x] 16 new unit tests (7 for ColorSwatchPicker, 9 for ColorPickerDialog)
- [x] Zero regressions on existing 2908 tests
- [x] TypeScript clean (`tsc --noEmit` passes)
- [ ] Manual: Right-click group in sidebar > "Change Color" shows swatch dialog
- [ ] Manual: Settings > Groups > color picker includes custom color swatch
- [ ] Manual: Settings > Repo > color picker uses shared component

🤖 Generated with [Claude Code](https://claude.com/claude-code)