### PR TITLE
feat: register plugin capabilities server-side

### DIFF
--- a/src/plugins/pluginLoader.ts
+++ b/src/plugins/pluginLoader.ts
@@ -156,7 +156,7 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<vo
   if (enabled) {
     if (builtIn) {
       // Re-register built-in plugin
-      await pluginRegistry.register(builtIn);
+      pluginRegistry.register(builtIn);
       pluginStore.updatePlugin(id, { loaded: true, error: null });
     } else {
       // Load external plugin from disk
@@ -180,6 +180,7 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<vo
     } else if (loadedPluginIds.has(id)) {
       pluginRegistry.unregister(id);
       loadedPluginIds.delete(id);
+      invoke("unregister_loaded_plugin", { pluginId: id }).catch(() => {});
     }
   }
 }
@@ -224,8 +225,20 @@ async function loadPlugin(manifest: PluginManifest): Promise<void> {
   }
 
   const plugin = (mod as { default: TuiPlugin }).default;
-  await pluginRegistry.register(plugin, manifest.capabilities, manifest.allowedUrls, manifest.agentTypes);
+  pluginRegistry.register(plugin, manifest.capabilities, manifest.allowedUrls, manifest.agentTypes);
   loadedPluginIds.add(manifest.id);
+
+  // Register capabilities server-side so Rust commands can enforce them
+  try {
+    await invoke("register_loaded_plugin", {
+      pluginId: manifest.id,
+      capabilities: manifest.capabilities,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`Failed to register capabilities server-side: ${msg}`);
+  }
+
   logger.info(`Loaded v${manifest.version}`);
   appLogger.info("plugin", `Loaded plugin "${manifest.id}" v${manifest.version}`);
 }
@@ -249,6 +262,7 @@ async function handlePluginChanged(event: { payload: string[] }): Promise<void> 
     if (loadedPluginIds.has(pluginId)) {
       pluginRegistry.unregister(pluginId);
       loadedPluginIds.delete(pluginId);
+      invoke("unregister_loaded_plugin", { pluginId }).catch(() => {});
     }
 
     // Re-discover this specific plugin's manifest


### PR DESCRIPTION
## Summary
- Sync loaded plugin capabilities with the Rust backend via `register_loaded_plugin` / `unregister_loaded_plugin` Tauri commands
- Enables server-side capability enforcement so Rust commands can validate plugin permissions
- Makes `pluginRegistry.register` calls synchronous to match its actual signature

## Test plan
- [ ] Verify plugins load correctly and capabilities are registered in the Rust backend
- [ ] Verify disabling a plugin calls `unregister_loaded_plugin`
- [ ] Verify hot-reload (plugin changed) unregisters before re-registering
- [ ] Verify graceful handling when server-side registration fails (warning logged, plugin still loads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)