### PR TITLE
fix(macos): add audio-input entitlement for microphone access

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `src-tauri/Entitlements.plist` with `com.apple.security.device.audio-input` entitlement
- Without this entitlement, macOS TCC never shows the app in the microphone permission prompt, making dictation unusable on signed builds

## Notes for @sstraus
The entitlement file needs to be referenced during code signing. The release build must pass `--entitlements src-tauri/Entitlements.plist` to `codesign` so the Developer ID signed bundle includes it.

## Test plan
- [ ] Rebuild and sign with entitlements
- [ ] `tccutil reset Microphone com.tuic.commander`
- [ ] Launch app, trigger dictation — microphone permission prompt should appear
- [ ] Verify with `codesign -d --entitlements :- /path/to/TUICommander.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)