### PR TITLE
fix(macos): add microphone entitlement for dictation

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,7 +59,10 @@
         "role": "Viewer",
         "mimeType": "text/markdown"
       }
-    ]
+    ],
+    "macOS": {
+      "entitlements": "./Entitlements.plist"
+    }
   },
   "plugins": {
     "deep-link": {


### PR DESCRIPTION
## Summary
- Add `Entitlements.plist` with `com.apple.security.device.audio-input` entitlement for microphone access
- Reference the entitlements file in `tauri.conf.json` via `bundle.macOS.entitlements` so Tauri actually applies it during code signing
- Without this config, macOS never shows the microphone permission prompt in System Settings, blocking dictation

## Test plan
- [ ] Build the app with `npm run tauri build`
- [ ] Launch the bundled `.app` from `src-tauri/target/release/bundle/macos/`
- [ ] Open dictation settings and click "Detect Microphones"
- [ ] Verify macOS shows the microphone permission prompt
- [ ] Verify the app appears in System Settings > Privacy & Security > Microphone

🤖 Generated with [Claude Code](https://claude.com/claude-code)