### PR TITLE
feat(branches): add human-readable labels for branches and worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ docs/book
 # Local embedding cache (mdkb/fastembed model files)
 .fastembed_cache/
 .vscode/
+docs/superpowers/

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -783,6 +783,9 @@ pub(crate) struct RepoSettingsEntry {
     /// Allowlist of upstream MCP server names relevant to this repo (None = all)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) mcp_upstreams: Option<Vec<String>>,
+    /// Human-readable labels for branches/worktrees, keyed by branch name
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(crate) branch_labels: HashMap<String, String>,
 }
 
 impl RepoSettingsEntry {
@@ -1007,6 +1010,32 @@ pub(crate) fn load_repo_settings() -> RepoSettingsMap {
 #[tauri::command]
 pub(crate) fn save_repo_settings(config: RepoSettingsMap) -> Result<(), String> {
     save_json_config(REPO_SETTINGS_FILE, &config)
+}
+
+/// Set or clear a human-readable label for a branch/worktree within a repo.
+/// `label = None` removes the label. Idempotent; no-ops on unknown repo paths.
+#[tauri::command]
+pub(crate) fn set_branch_label(repo_path: String, branch_name: String, label: Option<String>) -> Result<(), String> {
+    let mut settings: RepoSettingsMap = load_json_config(REPO_SETTINGS_FILE);
+    if let Some(entry) = settings.repos.get_mut(&repo_path) {
+        match label {
+            Some(l) if !l.trim().is_empty() => { entry.branch_labels.insert(branch_name, l.trim().to_string()); }
+            _ => { entry.branch_labels.remove(&branch_name); }
+        }
+        save_json_config(REPO_SETTINGS_FILE, &settings)
+    } else {
+        Ok(())
+    }
+}
+
+/// Remove a branch label — called by worktree deletion to keep config tidy.
+pub(crate) fn remove_branch_label(repo_path: &str, branch_name: &str) {
+    let mut settings: RepoSettingsMap = load_json_config(REPO_SETTINGS_FILE);
+    if let Some(entry) = settings.repos.get_mut(repo_path) {
+        if entry.branch_labels.remove(branch_name).is_some() {
+            let _ = save_json_config(REPO_SETTINGS_FILE, &settings);
+        }
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1333,6 +1333,7 @@ pub fn run() {
             config::save_ui_prefs,
             config::load_repo_settings,
             config::save_repo_settings,
+            config::set_branch_label,
             config::load_repo_local_config,
             mcp_upstream_config::load_mcp_upstreams,
             mcp_upstream_config::save_mcp_upstreams,

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -394,6 +394,7 @@ pub(crate) fn remove_worktree_by_branch(repo_path: &str, branch_name: &str, dele
 pub(crate) fn remove_worktree(state: State<'_, Arc<AppState>>, repo_path: String, branch_name: String, delete_branch: Option<bool>) -> Result<(), String> {
     let script = resolve_archive_script(&repo_path);
     remove_worktree_by_branch(&repo_path, &branch_name, delete_branch.unwrap_or(true), script.as_deref())?;
+    crate::config::remove_branch_label(&repo_path, &branch_name);
     state.invalidate_repo_caches(&repo_path);
     Ok(())
 }

--- a/src/__tests__/components/RepoSettingsPanel.test.tsx
+++ b/src/__tests__/components/RepoSettingsPanel.test.tsx
@@ -101,6 +101,7 @@ describe("SettingsPanel — repo context", () => {
       autoFetchIntervalMinutes: null,
       autoDeleteOnPrClose: null,
       mcpUpstreams: null,
+      branchLabels: {},
     };
     vi.mocked(repoSettingsStore.getOrCreate).mockReturnValue(mockSettings);
   });

--- a/src/__tests__/components/Sidebar.test.tsx
+++ b/src/__tests__/components/Sidebar.test.tsx
@@ -60,6 +60,8 @@ vi.mock("../../stores/repositories", () => ({
 vi.mock("../../stores/repoSettings", () => ({
   repoSettingsStore: {
     get: vi.fn(() => undefined),
+    getEffective: vi.fn(() => undefined),
+    setLabel: vi.fn(),
   },
 }));
 
@@ -955,8 +957,8 @@ describe("Sidebar", () => {
       expect(contextMenu).not.toBeNull();
 
       const items = contextMenu!.querySelectorAll(".item");
-      // Copy Path, Add Terminal, Rename Branch (no Delete Worktree for main)
-      expect(items.length).toBe(3);
+      // Copy Path, Add Terminal, Set Label…, Rename Branch (no Delete Worktree for main)
+      expect(items.length).toBe(4);
     });
 
     it("context menu Copy Path action copies worktreePath to clipboard", async () => {
@@ -1027,8 +1029,8 @@ describe("Sidebar", () => {
 
       const contextMenu = container.querySelector(".menu");
       const items = contextMenu!.querySelectorAll(".item");
-      // Copy Path, Add Terminal, Rename Branch (NO Delete Worktree)
-      expect(items.length).toBe(3);
+      // Copy Path, Add Terminal, Set Label…, Rename Branch (NO Delete Worktree)
+      expect(items.length).toBe(4);
       const labels = Array.from(items).map((i) => i.querySelector(".label")!.textContent);
       expect(labels).not.toContain("Delete Worktree");
     });
@@ -1049,8 +1051,8 @@ describe("Sidebar", () => {
 
       const contextMenu = container.querySelector(".menu");
       const items = contextMenu!.querySelectorAll(".item");
-      // Copy Path, Add Terminal, Rename Branch, Delete Worktree
-      expect(items.length).toBe(4);
+      // Copy Path, Add Terminal, Set Label…, Rename Branch, Delete Worktree
+      expect(items.length).toBe(5);
       const labels = Array.from(items).map((i) => i.querySelector(".label")!.textContent);
       expect(labels).toContain("Delete Worktree");
     });

--- a/src/components/PromptDialog/PromptDialog.tsx
+++ b/src/components/PromptDialog/PromptDialog.tsx
@@ -5,6 +5,7 @@ import d from "../shared/dialog.module.css";
 export interface PromptDialogProps {
   visible: boolean;
   title: string;
+  subtitle?: string;
   placeholder?: string;
   defaultValue?: string;
   confirmLabel?: string;
@@ -55,7 +56,12 @@ export const PromptDialog: Component<PromptDialogProps> = (props) => {
       <div class={d.overlay} onClick={props.onClose}>
         <div class={d.popover} onClick={(e) => e.stopPropagation()}>
           <div class={d.header}>
-            <h4>{props.title}</h4>
+            <div class={d.headerText}>
+              <h4>{props.title}</h4>
+              <Show when={props.subtitle}>
+                <p class={d.subtitle}>{props.subtitle}</p>
+              </Show>
+            </div>
           </div>
           <div class={d.body}>
             <input

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -17,6 +17,7 @@ import { invoke } from "../../invoke";
 import { cx } from "../../utils";
 import { t } from "../../i18n";
 import { sidebarPluginStore } from "../../stores/sidebarPluginStore";
+import { repoSettingsStore } from "../../stores/repoSettings";
 import { contextMenuActionsStore } from "../../stores/contextMenuActionsStore";
 import { SidebarPluginSection } from "./SidebarPluginSection";
 import { remoteUrlToGitHub } from "../GitPanel/BranchesTab";
@@ -190,8 +191,13 @@ export const BranchItem: Component<{
   currentBranch?: () => string;
   githubBaseUrl?: string | null;
   repoHasTerminals: boolean;
+  onSetLabel?: (currentLabel: string | undefined) => void;
 }> = (props) => {
   const ctxMenu = createContextMenu();
+
+  const branchLabel = createMemo(() =>
+    repoSettingsStore.getEffective(props.repoPath)?.branchLabels?.[props.branch.name],
+  );
 
   const pr = createMemo(() => activePrStatus(props.repoPath, props.branch.name));
   const checks = createMemo(() => githubStore.getCheckSummary(props.repoPath, props.branch.name));
@@ -235,6 +241,12 @@ export const BranchItem: Component<{
       { label: "Copy Path", action: handleCopyPath, disabled: !props.branch.worktreePath },
       { label: "Add Terminal", action: props.onAddTerminal },
     ];
+    if (!props.branch.isShell && props.branch.name) {
+      items.push({ label: "Set Label…", action: () => props.onSetLabel?.(branchLabel()) });
+      if (branchLabel()) {
+        items.push({ label: "Clear Label", action: () => repoSettingsStore.setLabel(props.repoPath, props.branch.name, null) });
+      }
+    }
     if (!props.branch.isShell) {
       const agentItems = props.agentMenuItems?.();
       if (agentItems && agentItems.length > 0) {
@@ -314,10 +326,13 @@ export const BranchItem: Component<{
         <span
           class={s.branchName}
           onDblClick={handleDoubleClick}
-          title={props.branch.name}
+          title={branchLabel() ?? props.branch.name}
         >
-          {props.branch.name}
+          {branchLabel() ?? props.branch.name}
         </span>
+        <Show when={branchLabel()}>
+          <span class={s.branchSubLabel} title={props.branch.name}>{props.branch.name}</span>
+        </Show>
       </div>
       <Show when={props.branch.isMerged && !props.branch.isMain && !props.branch.terminals.length && !(props.branch.additions + props.branch.deletions)}>
         <span class={s.mergedBadge} title="Branch is merged into main">Merged</span>
@@ -412,6 +427,7 @@ export const RepoSection: Component<{
   onMouseDrag: (e: MouseEvent) => void;
 }> = (props) => {
   const repoMenu = createContextMenu();
+  const [labelDialogBranch, setLabelDialogBranch] = createSignal<{ name: string; current: string | undefined } | null>(null);
   const [groupPromptVisible, setGroupPromptVisible] = createSignal(false);
   const [remoteOnlyPopoverVisible, setRemoteOnlyPopoverVisible] = createSignal(false);
   const [remoteCleanupActive, setRemoteCleanupActive] = createSignal(false);
@@ -589,6 +605,7 @@ export const RepoSection: Component<{
                 onAddTerminal={() => props.onAddTerminal(branch.name)}
                 onRemove={() => props.onRemoveBranch(branch.name)}
                 onRename={() => props.onRenameBranch(branch.name)}
+                onSetLabel={(current) => setLabelDialogBranch({ name: branch.name, current })}
                 onShowPrDetail={() => props.onShowPrDetail(branch.name)}
                 onShowChanges={props.onShowChanges}
                 onCreateWorktreeFromBranch={props.onCreateWorktreeFromBranch ? () => props.onCreateWorktreeFromBranch!(branch.name) : undefined}
@@ -617,6 +634,20 @@ export const RepoSection: Component<{
         y={repoMenu.position().y}
         visible={repoMenu.visible()}
         onClose={repoMenu.close}
+      />
+      <PromptDialog
+        visible={!!labelDialogBranch()}
+        title="Set Label"
+        placeholder="Human-readable name…"
+        confirmLabel="Save"
+        defaultValue={labelDialogBranch()?.current ?? ""}
+        subtitle={labelDialogBranch()?.name}
+        onClose={() => setLabelDialogBranch(null)}
+        onConfirm={(label) => {
+          const b = labelDialogBranch();
+          if (b) repoSettingsStore.setLabel(props.repo.path, b.name, label || null);
+          setLabelDialogBranch(null);
+        }}
       />
       <PromptDialog
         visible={groupPromptVisible()}

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -461,6 +461,17 @@
   text-overflow: ellipsis;
 }
 
+.branchSubLabel {
+  display: block;
+  font-size: 10px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: monospace;
+  line-height: 1.3;
+}
+
 .branchStats {
   display: flex;
   gap: 4px;

--- a/src/components/WorktreeManager/WorktreeManager.module.css
+++ b/src/components/WorktreeManager/WorktreeManager.module.css
@@ -241,6 +241,16 @@
   text-overflow: ellipsis;
 }
 
+.branchSubLabel {
+  font-size: 10px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: monospace;
+  line-height: 1.3;
+}
+
 .worktreePath {
   font-size: var(--font-2xs);
   font-family: var(--font-ui);

--- a/src/components/WorktreeManager/WorktreeManager.tsx
+++ b/src/components/WorktreeManager/WorktreeManager.tsx
@@ -3,6 +3,7 @@ import { invoke } from "../../invoke";
 import { appLogger } from "../../stores/appLogger";
 import { worktreeManagerStore } from "../../stores/worktreeManager";
 import { repositoriesStore } from "../../stores/repositories";
+import { repoSettingsStore } from "../../stores/repoSettings";
 import { githubStore } from "../../stores/github";
 import { formatRelativeTime } from "../../utils/time";
 import type { BranchPrStatus } from "../../types";
@@ -309,7 +310,12 @@ export const WorktreeManager: Component<{ actions?: WorktreeActions }> = (props)
                   <span class={s.repo}>{wt.repoName}</span>
                   {/* Col 3: Branch + worktree path */}
                   <div class={s.branchCell}>
-                    <span class={s.branch}>{wt.branch}</span>
+                    <span class={s.branch}>
+                      {repoSettingsStore.getEffective(wt.repoPath)?.branchLabels?.[wt.branch] ?? wt.branch}
+                    </span>
+                    <Show when={repoSettingsStore.getEffective(wt.repoPath)?.branchLabels?.[wt.branch]}>
+                      <span class={s.branchSubLabel}>{wt.branch}</span>
+                    </Show>
                     <span class={s.worktreePath}>{wt.worktreePath}</span>
                   </div>
                   {/* Col 4: Badges */}

--- a/src/components/shared/dialog.module.css
+++ b/src/components/shared/dialog.module.css
@@ -39,6 +39,13 @@
   border-bottom: 1px solid var(--border);
 }
 
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 .headerIcon {
   font-size: var(--font-xl);
   color: var(--accent);
@@ -49,6 +56,16 @@
   font-size: var(--font-lg);
   font-weight: 600;
   color: var(--fg-primary);
+}
+
+.subtitle {
+  margin: 2px 0 0;
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .body {

--- a/src/hooks/useGitOperations.ts
+++ b/src/hooks/useGitOperations.ts
@@ -447,14 +447,17 @@ export function useGitOperations(deps: GitOperationsDeps) {
     const branch = repositoriesStore.get(repoPath)?.branches[branchName];
     const termCount = branch?.terminals.length || 0;
 
+    const label = repoSettingsStore.getEffective(repoPath)?.branchLabels?.[branchName];
+    const tabName = label ?? `${branchName.split(/[\\/]/).pop()} ${termCount + 1}`;
     const id = terminalsStore.add({
       sessionId: null,
       fontSize: deps.getDefaultFontSize(),
-      name: `${branchName.split(/[\\/]/).pop()} ${termCount + 1}`,
+      name: tabName,
       cwd: branch?.worktreePath || null,
       awaitingInput: null,
       tuicSession: crypto.randomUUID(),
     });
+    if (label) terminalsStore.update(id, { nameIsCustom: true });
 
     batch(() => {
       if (needsSwitch) {

--- a/src/stores/repoSettings.ts
+++ b/src/stores/repoSettings.ts
@@ -43,6 +43,8 @@ export interface RepoSettings {
   autoDeleteOnPrClose: AutoDeleteOnPrClose | null;
   /** Allowlist of upstream MCP server names for this repo (null = all servers) */
   mcpUpstreams: string[] | null;
+  /** Human-readable labels for branches/worktrees, keyed by branch name */
+  branchLabels: Record<string, string>;
 }
 
 /** Fully resolved settings with no nulls — use getEffective() to obtain */
@@ -68,6 +70,8 @@ export interface EffectiveRepoSettings {
   autoDeleteOnPrClose: AutoDeleteOnPrClose;
   /** Resolved MCP upstream allowlist (null = all servers) */
   mcpUpstreams: string[] | null;
+  /** Human-readable labels for branches/worktrees, keyed by branch name */
+  branchLabels: Record<string, string>;
 }
 
 /** Fields that can be overridden per-repo (all others are repo-specific) */
@@ -177,6 +181,7 @@ function createRepoSettingsStore() {
         path,
         displayName,
         color: "",
+        branchLabels: {},
         ...OVERRIDABLE_NULL_DEFAULTS,
       };
 
@@ -229,6 +234,7 @@ function createRepoSettingsStore() {
         autoFetchIntervalMinutes: settings.autoFetchIntervalMinutes ?? defaults.autoFetchIntervalMinutes,
         autoDeleteOnPrClose: settings.autoDeleteOnPrClose ?? local?.auto_delete_on_pr_close ?? defaults.autoDeleteOnPrClose,
         mcpUpstreams: settings.mcpUpstreams ?? local?.mcp_upstreams ?? null,
+        branchLabels: settings.branchLabels ?? {},
       };
     },
 
@@ -238,6 +244,22 @@ function createRepoSettingsStore() {
 
       setState("settings", path, { ...state.settings[path], ...updates });
       saveSettings(state.settings);
+    },
+
+    /** Set or clear a human-readable label for a branch/worktree. `null` removes it. */
+    setLabel(repoPath: string, branchName: string, label: string | null): void {
+      const current = state.settings[repoPath];
+      if (!current) return;
+      const next = { ...current.branchLabels };
+      if (label && label.trim()) {
+        next[branchName] = label.trim();
+      } else {
+        delete next[branchName];
+      }
+      setState("settings", repoPath, "branchLabels", reconcile(next));
+      invoke("set_branch_label", { repoPath, branchName, label: label?.trim() || null }).catch((err) =>
+        appLogger.error("config", "Failed to set branch label", err),
+      );
     },
 
     /** Remove settings for a repository */


### PR DESCRIPTION
## Summary

- Adds a **Set Label…** context menu item on branch/worktree items in the Sidebar
- Label replaces the branch name visually; real branch name shown beneath as a monospace sub-label
- Labels persist in `repo-settings.json` via a new `branch_labels` map (Rust `RepoSettingsEntry` + TS `RepoSettings`)
- New Tauri command `set_branch_label` exposes get/set/clear from the frontend
- Labels auto-removed on worktree deletion (`remove_worktree` calls `remove_branch_label`)
- WorktreeManager panel also displays labels with the same sub-label treatment
- Terminal tab uses the branch label as its name when one is set
- `PromptDialog` gains an optional `subtitle` prop (shows the branch name under the dialog title)
- Tests updated: item counts in Sidebar context menu tests reflect new "Set Label…" / "Clear Label" items

## Screenshots
<img width="258" height="76" alt="Screenshot 2026-05-05 at 17 59 55" src="https://github.com/user-attachments/assets/64ec7cb7-820d-4084-a882-80b5ac8f07d8" />
<img width="389" height="278" alt="Screenshot 2026-05-05 at 17 59 40" src="https://github.com/user-attachments/assets/7dbf9310-9113-456b-932c-348671f3fe03" />



## Test plan

- [ ] Right-click a branch → "Set Label…" → type a label → Save: label appears in place of branch name, real name shown beneath
- [ ] Right-click a labelled branch → "Clear Label": reverts to branch name
- [ ] Label persists after app restart (written to `repo-settings.json`)
- [ ] Deleting a worktree removes its label from settings
- [ ] WorktreeManager shows label + sub-label for labelled branches
- [ ] New terminal opened from a labelled branch uses label as tab name
- [ ] `npx vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)