### PR TITLE
feat(remote): headless tuicommander-remote binary

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8051,7 +8051,7 @@ dependencies = [
 
 [[package]]
 name = "tuicommander"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "alacritty_terminal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,9 +11,14 @@ default-run = "tuicommander"
 
 [profile.release]
 incremental = true
+
 [lib]
 name = "tuicommander_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+
+[[bin]]
+name = "tuicommander-remote"
+path = "src/bin/tuicommander_remote.rs"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [], optional = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,11 +16,11 @@ name = "tuicommander_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2", features = [], optional = true }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
-tauri-plugin-opener = "2"
+tauri = { version = "2", features = ["protocol-asset"], optional = true }
+tauri-plugin-opener = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.9"
@@ -31,16 +31,16 @@ regex = "1"
 lazy_static = "1"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
-tauri-plugin-dialog = "2.6.0"
-tauri-plugin-single-instance = "2"
-whisper-rs = "0.16"
-cpal = "0.17"
-rodio = "0.20"
+tauri-plugin-dialog = { version = "2.6.0", optional = true }
+tauri-plugin-single-instance = { version = "2", optional = true }
+whisper-rs = { version = "0.16", optional = true }
+cpal = { version = "0.17", optional = true }
+rodio = { version = "0.20", optional = true }
 reqwest = { version = "0.13", features = ["stream", "json", "form"] }
 futures-util = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 async-stream = "0.3"
-tauri-plugin-window-state = "2.4.1"
+tauri-plugin-window-state = { version = "2.4.1", optional = true }
 bcrypt = "0.19"
 base64 = "0.22"
 include_dir = { version = "0.7.4", features = ["glob"] }
@@ -51,11 +51,11 @@ libc = "0.2"
 notify = "8"
 gh-token = "0.1"
 keepawake = "0.6"
-tauri-plugin-updater = "2"
-tauri-plugin-process = "2"
-tauri-plugin-deep-link = "2"
-tauri-plugin-clipboard-manager = "2"
-tauri-plugin-global-shortcut = "2"
+tauri-plugin-updater = { version = "2", optional = true }
+tauri-plugin-process = { version = "2", optional = true }
+tauri-plugin-deep-link = { version = "2", optional = true }
+tauri-plugin-clipboard-manager = { version = "2", optional = true }
+tauri-plugin-global-shortcut = { version = "2", optional = true }
 zip = "8"
 glob = "0.3"
 ignore = "0.4"
@@ -88,21 +88,40 @@ toml = "0.8"
 
 [features]
 default = ["desktop"]
-desktop = []
+desktop = [
+    "dep:tauri",
+    "dep:tauri-build",
+    "dep:tauri-plugin-opener",
+    "dep:tauri-plugin-dialog",
+    "dep:tauri-plugin-single-instance",
+    "dep:tauri-plugin-window-state",
+    "dep:tauri-plugin-updater",
+    "dep:tauri-plugin-process",
+    "dep:tauri-plugin-deep-link",
+    "dep:tauri-plugin-clipboard-manager",
+    "dep:tauri-plugin-global-shortcut",
+    "dep:whisper-rs",
+    "dep:cpal",
+    "dep:rodio",
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-app-kit",
+    "dep:block2",
+]
 # GPU features for Linux builds (macOS always has Metal, Windows always has Vulkan via target deps)
 cuda = ["whisper-rs/cuda"]
 vulkan = ["whisper-rs/vulkan"]
 tokio-console = ["console-subscriber"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-whisper-rs = { version = "0.16", features = ["metal"] }
-objc2 = "0.6"
-objc2-foundation = "0.3"
-objc2-app-kit = { version = "0.3", features = ["NSEvent", "block2"] }
-block2 = "0.6"
+whisper-rs = { version = "0.16", features = ["metal"], optional = true }
+objc2 = { version = "0.6", optional = true }
+objc2-foundation = { version = "0.3", optional = true }
+objc2-app-kit = { version = "0.3", features = ["NSEvent", "block2"], optional = true }
+block2 = { version = "0.6", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-whisper-rs = { version = "0.16", features = ["vulkan"] }
+whisper-rs = { version = "0.16", features = ["vulkan"], optional = true }
 windows-sys = { version = "0.61", features = ["Win32_System_Diagnostics_ToolHelp", "Win32_Foundation"] }
 
 [patch.crates-io]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,7 +87,8 @@ cron = "0.16"
 toml = "0.8"
 
 [features]
-default = []
+default = ["desktop"]
+desktop = []
 # GPU features for Linux builds (macOS always has Metal, Windows always has Vulkan via target deps)
 cuda = ["whisper-rs/cuda"]
 vulkan = ["whisper-rs/vulkan"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -14,5 +14,6 @@ fn main() {
         std::env::var("TARGET").unwrap_or_default()
     );
 
-    tauri_build::build()
+    #[cfg(feature = "desktop")]
+    tauri_build::build();
 }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, State};
 use uuid::Uuid;
 
@@ -51,7 +52,7 @@ fn goto_editor_cmd(
 
 /// Open a path in an IDE or application.
 /// `line` and `col` are optional and only used by editors that support them.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn open_in_app(
     path: String,
     app: String,
@@ -180,7 +181,7 @@ pub(crate) fn open_in_app(
 }
 
 /// Detect installed IDE applications (cross-platform)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn detect_installed_ides() -> Vec<String> {
     let mut installed = Vec::new();
 
@@ -300,7 +301,7 @@ pub(crate) struct AgentBinaryDetection {
 }
 
 /// Detect any agent binary location
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn detect_agent_binary(binary: String) -> AgentBinaryDetection {
     let home = dirs::home_dir()
         .unwrap_or_default()
@@ -382,7 +383,7 @@ pub(crate) fn detect_agent_binary(binary: String) -> AgentBinaryDetection {
 /// Batch-detect multiple agent binaries in parallel.
 /// Returns a map of binary name -> detection result.
 /// Skips version detection for speed; use detect_agent_binary for full info.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn detect_all_agent_binaries(
     binaries: Vec<String>,
 ) -> std::collections::HashMap<String, AgentBinaryDetection> {
@@ -516,7 +517,7 @@ fn get_binary_version(path: &str) -> Option<String> {
 }
 
 /// Detect claude binary location (legacy, delegates to detect_agent_binary)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn detect_claude_binary() -> Result<String, String> {
     let detection = detect_agent_binary("claude".to_string());
     detection.path.ok_or_else(|| {
@@ -525,6 +526,7 @@ pub(crate) fn detect_claude_binary() -> Result<String, String> {
 }
 
 /// Spawn an agent in a PTY
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn spawn_agent(
     app: AppHandle,

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -529,7 +529,7 @@ pub(crate) fn detect_claude_binary() -> Result<String, String> {
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn spawn_agent(
-    app: AppHandle,
+    _app: AppHandle,
     state: State<'_, Arc<AppState>>,
     pty_config: PtyConfig,
     agent_config: AgentConfig,
@@ -653,7 +653,6 @@ pub(crate) async fn spawn_agent(
         reader,
         paused,
         session_id.clone(),
-        app,
         state.inner().clone(),
         None,
     );

--- a/src-tauri/src/agent_mcp.rs
+++ b/src-tauri/src/agent_mcp.rs
@@ -429,7 +429,7 @@ pub(crate) fn ensure_mcp_configs(disabled: &[String]) {
 // ---------------------------------------------------------------------------
 
 /// Check MCP installation status for an agent
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_agent_mcp_status(agent_type: String) -> AgentMcpStatus {
     // Codex uses TOML — handle separately
     if agent_type == "codex" {
@@ -474,6 +474,7 @@ pub(crate) fn get_agent_mcp_status(agent_type: String) -> AgentMcpStatus {
 
 /// Install the tui-mcp-bridge MCP entry into an agent's config.
 /// Also removes the agent from `disabled_mcp_agents` so `ensure_mcp_configs` won't skip it.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn install_agent_mcp(
     agent_type: String,
@@ -520,6 +521,7 @@ pub(crate) fn install_agent_mcp(
 
 /// Remove the tui-mcp-bridge MCP entry from an agent's config.
 /// Also adds the agent to `disabled_mcp_agents` so `ensure_mcp_configs` won't reinstall it.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn remove_agent_mcp(
     agent_type: String,
@@ -579,7 +581,7 @@ fn update_disabled_mcp_agents(
 }
 
 /// Get the path to an agent's own configuration file
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_agent_config_path(agent_type: String) -> Option<String> {
     get_agent_settings_path(&agent_type).map(|p| p.to_string_lossy().to_string())
 }
@@ -592,7 +594,7 @@ pub(crate) struct McpBridgeInfo {
 }
 
 /// Return bridge path + ready-to-paste JSON snippet for manual MCP setup
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_mcp_bridge_info() -> McpBridgeInfo {
     let bridge_path = detect_bridge_binary();
     let entry = TuicMcpEntry {

--- a/src-tauri/src/agent_session.rs
+++ b/src-tauri/src/agent_session.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 /// - `agent_type`: one of `"claude"`, `"gemini"`, `"codex"`, `"goose"`
 /// - `cwd`: the terminal's working directory (used to compute project-scoped paths)
 /// - `claimed_ids`: session IDs already assigned to other terminals — excluded from results
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn discover_agent_session(
     agent_type: String,
     cwd: String,
@@ -42,7 +42,7 @@ pub(crate) fn discover_agent_session(
 
 /// Return the absolute path to Claude Code's project directory for a given CWD.
 /// E.g. `/Users/foo/bar` → `~/.claude/projects/-Users-foo-bar`.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn claude_project_dir(cwd: String) -> Result<String, String> {
     let base = claude_projects_dir()
         .ok_or_else(|| "Could not determine home directory".to_string())?;
@@ -224,7 +224,7 @@ fn extract_codex_uuid(name: &str) -> Option<String> {
 ///
 /// Used at restore time to decide if `--resume <uuid>` is safe: if the session
 /// file doesn't exist, the resume command would fail.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn verify_agent_session(
     agent_type: String,
     session_id: String,
@@ -244,7 +244,7 @@ pub(crate) fn verify_agent_session(
 /// `--session-id <stale-uuid>` on the first manual `claude` invocation, which
 /// would cause Claude to exit immediately and leak VT probe responses (DA1,
 /// DECRPM) as visible garbage in the shell.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn preflight_session_inject(tuic_session: String, cwd: String) {
     if !tuic_session.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
         || tuic_session.len() != 36

--- a/src-tauri/src/ai_agent/commands.rs
+++ b/src-tauri/src/ai_agent/commands.rs
@@ -1,6 +1,8 @@
 //! Tauri IPC commands for the agent loop API.
 
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::state::AppState;
@@ -43,6 +45,7 @@ fn build_llm_runtime() -> Result<LlmRuntime, String> {
 }
 
 /// Start an agent loop on a terminal session.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn start_agent_loop(
     state: State<'_, Arc<AppState>>,
@@ -95,7 +98,7 @@ pub(crate) async fn start_agent_loop(
 }
 
 /// Cancel an active agent loop.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn cancel_agent_loop(
     session_id: String,
 ) -> Result<String, String> {
@@ -104,7 +107,7 @@ pub(crate) async fn cancel_agent_loop(
 }
 
 /// Pause an active agent loop.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn pause_agent_loop(
     session_id: String,
 ) -> Result<String, String> {
@@ -113,7 +116,7 @@ pub(crate) async fn pause_agent_loop(
 }
 
 /// Resume a paused agent loop.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn resume_agent_loop(
     session_id: String,
 ) -> Result<String, String> {
@@ -122,7 +125,7 @@ pub(crate) async fn resume_agent_loop(
 }
 
 /// Get the status of an agent loop.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn agent_loop_status(
     session_id: String,
 ) -> Result<serde_json::Value, String> {
@@ -146,7 +149,7 @@ pub(crate) async fn agent_loop_status(
 
 /// Approve or reject a pending destructive command from the agent.
 /// Resolves the oneshot channel that the engine is blocking on.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn approve_agent_action(
     session_id: String,
     approved: bool,
@@ -274,7 +277,7 @@ pub(crate) struct KnowledgeListFilter {
 /// `ai-sessions/` on every call (no in-memory index yet) — acceptable up
 /// to a few hundred files; upgrade path is a sidecar index if this becomes
 /// a bottleneck.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn list_knowledge_sessions(
     filter: Option<KnowledgeListFilter>,
     limit: Option<usize>,
@@ -397,6 +400,7 @@ pub(crate) struct SessionDetail {
 /// Load the full command history for one session. Reads from disk if the
 /// session is not currently active — covers the "inspect last week's
 /// session" case from the story.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_knowledge_session_detail(
     state: State<'_, Arc<AppState>>,
@@ -450,12 +454,12 @@ fn history_command(c: &super::knowledge::CommandOutcome) -> HistoryCommand {
 
 // ── Scheduler commands ──────────────────────────────────────────
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_scheduler_config() -> super::scheduler::SchedulerConfig {
     super::scheduler::load_config()
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_scheduler_config(
     config: super::scheduler::SchedulerConfig,
 ) -> Result<(), String> {
@@ -464,6 +468,7 @@ pub(crate) fn save_scheduler_config(
 
 /// Return a frontend-friendly summary of the session's accumulated knowledge.
 /// Returns an empty summary if no commands have been recorded yet.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_session_knowledge(
     state: State<'_, Arc<AppState>>,

--- a/src-tauri/src/ai_agent/commands.rs
+++ b/src-tauri/src/ai_agent/commands.rs
@@ -87,6 +87,7 @@ pub(crate) async fn start_agent_loop(
     // subscribe via `listen("agent-loop-event", ...)`.
     if let Some(handle) = app_handle {
         tokio::spawn(async move {
+#[cfg(feature = "desktop")]
             use tauri::Emitter;
             while let Ok(event) = rx.recv().await {
                 let _ = handle.emit("agent-loop-event", &event);

--- a/src-tauri/src/ai_chat.rs
+++ b/src-tauri/src/ai_chat.rs
@@ -168,18 +168,18 @@ pub(crate) async fn detect_ollama(base: &str) -> OllamaStatus {
 // Tauri commands
 // ---------------------------------------------------------------------------
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_ai_chat_config() -> AiChatConfig {
     load_json_config(CONFIG_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_ai_chat_config(config: AiChatConfig) -> Result<(), String> {
     save_json_config(CONFIG_FILE, &config)
 }
 
 /// Quick connection test: first validate the API key, then send a minimal completion.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn test_ai_chat_connection() -> Result<String, String> {
     let registry = crate::provider_registry::load_registry();
     let resolved = crate::provider_registry::resolve_slot(&registry, crate::provider_registry::SlotName::Chat)
@@ -296,7 +296,7 @@ fn now_millis() -> u64 {
         .as_millis() as u64
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn list_conversations() -> Result<Vec<ConversationMeta>, String> {
     #[derive(serde::Deserialize)]
     struct MetaOnly { meta: ConversationMeta }
@@ -320,7 +320,7 @@ pub(crate) fn list_conversations() -> Result<Vec<ConversationMeta>, String> {
     Ok(metas)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_conversation(id: String) -> Result<Conversation, String> {
     crate::ai_agent::knowledge::validate_file_stem(&id)?;
     let dir = conversations_dir()?;
@@ -332,7 +332,7 @@ pub(crate) fn load_conversation(id: String) -> Result<Conversation, String> {
     Ok(conv)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_conversation(mut conversation: Conversation) -> Result<(), String> {
     crate::ai_agent::knowledge::validate_file_stem(&conversation.meta.id)?;
     conversation.sanitize_for_persist();
@@ -343,7 +343,7 @@ pub(crate) fn save_conversation(mut conversation: Conversation) -> Result<(), St
     crate::config::persist_atomic(&path, data.as_bytes())
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn delete_conversation(id: String) -> Result<(), String> {
     crate::ai_agent::knowledge::validate_file_stem(&id)?;
     let dir = conversations_dir()?;
@@ -355,7 +355,7 @@ pub(crate) fn delete_conversation(id: String) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn new_conversation_id() -> String {
     use std::fmt::Write;
     let ts = now_millis();
@@ -703,6 +703,7 @@ pub(crate) struct StreamChatMessage {
     pub content: String,
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn stream_ai_chat(
     state: tauri::State<'_, Arc<AppState>>,
@@ -954,7 +955,7 @@ async fn stream_with_batching(
     }
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn cancel_ai_chat(chat_id: String) -> Result<(), String> {
     let active = ACTIVE_CHATS.lock().await;
     if let Some(flag) = active.get(&chat_id) {

--- a/src-tauri/src/ai_chat.rs
+++ b/src-tauri/src/ai_chat.rs
@@ -837,6 +837,7 @@ pub(crate) async fn stream_ai_chat(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 /// Stream LLM response with ~50ms chunk batching to avoid IPC saturation.
 /// Returns the full response text on success.
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/ai_chat_registry.rs
+++ b/src-tauri/src/ai_chat_registry.rs
@@ -292,6 +292,7 @@ fn validate_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_subscribe(
     registry: tauri::State<'_, ChatRegistry>,
@@ -302,6 +303,7 @@ pub(crate) async fn chat_subscribe(
     Ok(registry.subscribe(&chat_id, on_event).await)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_unsubscribe(
     registry: tauri::State<'_, ChatRegistry>,
@@ -313,6 +315,7 @@ pub(crate) async fn chat_unsubscribe(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_get_state(
     registry: tauri::State<'_, ChatRegistry>,
@@ -322,6 +325,7 @@ pub(crate) async fn chat_get_state(
     Ok(registry.snapshot(&chat_id).await)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_attach_terminal(
     registry: tauri::State<'_, ChatRegistry>,
@@ -338,6 +342,7 @@ pub(crate) async fn chat_attach_terminal(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_detach_terminal(
     registry: tauri::State<'_, ChatRegistry>,
@@ -352,6 +357,7 @@ pub(crate) async fn chat_detach_terminal(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_clear(
     registry: tauri::State<'_, ChatRegistry>,
@@ -362,6 +368,7 @@ pub(crate) async fn chat_clear(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_set_pinned(
     registry: tauri::State<'_, ChatRegistry>,
@@ -377,6 +384,7 @@ pub(crate) async fn chat_set_pinned(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn chat_push_message(
     registry: tauri::State<'_, ChatRegistry>,

--- a/src-tauri/src/ai_chat_registry.rs
+++ b/src-tauri/src/ai_chat_registry.rs
@@ -62,6 +62,7 @@ pub struct SubscribeResult {
 
 const MAX_MESSAGES: usize = 100;
 
+#[cfg(feature = "desktop")]
 struct Subscriber {
     id: SubscriptionId,
     channel: tauri::ipc::Channel<ChatEvent>,
@@ -69,7 +70,22 @@ struct Subscriber {
 
 struct ChatSlot {
     state: ConversationState,
+    #[cfg(feature = "desktop")]
     subscribers: Vec<Subscriber>,
+}
+
+#[cfg(not(feature = "desktop"))]
+impl ChatSlot {
+    fn new() -> Self {
+        Self { state: ConversationState::default() }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl ChatSlot {
+    fn new() -> Self {
+        Self { state: ConversationState::default(), subscribers: Vec::new() }
+    }
 }
 
 /// Mutable conversation state (not directly serialized — use `snapshot()`).
@@ -118,10 +134,7 @@ impl ChatRegistry {
         self.chats
             .entry(chat_id.to_string())
             .or_insert_with(|| {
-                Arc::new(Mutex::new(ChatSlot {
-                    state: ConversationState::default(),
-                    subscribers: Vec::new(),
-                }))
+                Arc::new(Mutex::new(ChatSlot::new()))
             })
             .clone()
     }
@@ -149,6 +162,7 @@ impl ChatRegistry {
         guard.state.snapshot()
     }
 
+    #[cfg(feature = "desktop")]
     /// Subscribe a Channel to receive events for a chat.
     /// Returns the subscription ID and a snapshot of the current state
     /// (taken under the same lock to prevent races).
@@ -171,6 +185,7 @@ impl ChatRegistry {
         }
     }
 
+    #[cfg(feature = "desktop")]
     /// Remove a subscriber by ID.
     pub async fn unsubscribe(&self, chat_id: &str, sub_id: SubscriptionId) {
         if let Some(slot) = self.chats.get(chat_id) {
@@ -185,6 +200,7 @@ impl ChatRegistry {
     /// mutex. We clone the subscriber handles under the lock, drop it, then
     /// send. Dead channels (send returns Err) are garbage-collected via a
     /// short re-lock.
+    #[cfg(feature = "desktop")]
     pub async fn fan_out(&self, chat_id: &str, event: ChatEvent) {
         let slot = match self.chats.get(chat_id) {
             Some(s) => s.clone(),
@@ -220,6 +236,10 @@ impl ChatRegistry {
             guard.subscribers.retain(|s| !dead_ids.contains(&s.id));
         }
     }
+
+    /// No-op fan-out when desktop feature is disabled (no IPC subscribers).
+    #[cfg(not(feature = "desktop"))]
+    pub async fn fan_out(&self, _chat_id: &str, _event: ChatEvent) {}
 
     /// Convenience: update state + fan_out a Snapshot event.
     pub async fn update_and_notify<F>(&self, chat_id: &str, f: F)
@@ -268,6 +288,7 @@ impl ChatRegistry {
     }
 
     /// Number of subscribers for a chat (for testing/debug).
+    #[cfg(feature = "desktop")]
     #[allow(dead_code)]
     pub async fn subscriber_count(&self, chat_id: &str) -> usize {
         match self.chats.get(chat_id) {

--- a/src-tauri/src/app_logger.rs
+++ b/src-tauri/src/app_logger.rs
@@ -12,6 +12,7 @@
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{Manager, State};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -324,6 +325,7 @@ fn cleanup_old_logs(log_dir: &std::path::Path) {
 // ---------------------------------------------------------------------------
 
 /// Push a log entry from the frontend into the Rust ring buffer.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn push_log(
     state: State<'_, Arc<AppState>>,
@@ -337,6 +339,7 @@ pub(crate) fn push_log(
 }
 
 /// Retrieve log entries. Returns up to `limit` most recent entries (0 = all).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_logs(
     state: State<'_, Arc<AppState>>,
@@ -347,6 +350,7 @@ pub(crate) fn get_logs(
 }
 
 /// Clear all log entries.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn clear_logs(state: State<'_, Arc<AppState>>) {
     let mut buf = state.log_buffer.lock();

--- a/src-tauri/src/app_logger.rs
+++ b/src-tauri/src/app_logger.rs
@@ -357,6 +357,7 @@ pub(crate) fn clear_logs(state: State<'_, Arc<AppState>>) {
     buf.clear();
 }
 
+#[cfg(feature = "desktop")]
 /// Push a log entry from internal Rust code using an AppHandle.
 ///
 /// Use this in contexts where you have an `AppHandle` but not a `State<>` extractor

--- a/src-tauri/src/bin/tuicommander_remote.rs
+++ b/src-tauri/src/bin/tuicommander_remote.rs
@@ -1,0 +1,9 @@
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let port: u16 = std::env::var("TUIC_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(9877);
+
+    tuicommander_lib::run_headless(port).await
+}

--- a/src-tauri/src/bin/tuicommander_remote.rs
+++ b/src-tauri/src/bin/tuicommander_remote.rs
@@ -1,9 +1,19 @@
+#[cfg(not(feature = "desktop"))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let port: u16 = std::env::var("TUIC_PORT")
-        .ok()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(9877);
+    let port: u16 = match std::env::var("TUIC_PORT") {
+        Ok(val) => val.parse().unwrap_or_else(|e| {
+            eprintln!("warning: TUIC_PORT={val:?} is not a valid port ({e}), using default 9877");
+            9877
+        }),
+        Err(_) => 9877,
+    };
 
     tuicommander_lib::run_headless(port).await
+}
+
+#[cfg(feature = "desktop")]
+fn main() {
+    eprintln!("tuicommander-remote requires --no-default-features (desktop feature must be disabled)");
+    std::process::exit(1);
 }

--- a/src-tauri/src/claude_usage.rs
+++ b/src-tauri/src/claude_usage.rs
@@ -865,7 +865,7 @@ fn get_stale_cache() -> Option<UsageApiResponse> {
 
 /// Fetch rate-limit usage from the Anthropic OAuth API.
 /// Uses an in-memory cache (5 min TTL) and retries 429s with exponential backoff.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn get_claude_usage_api() -> Result<UsageApiResponse, String> {
     // Return fresh cache if available
     if let Some(cached) = try_get_fresh_cache() {
@@ -958,7 +958,7 @@ pub async fn get_claude_usage_api() -> Result<UsageApiResponse, String> {
 /// Returns hourly token usage points aggregated from the session stats cache.
 /// The `scope` parameter filters which projects to include ("all" or a slug).
 /// The `days` parameter limits the time window (default 7).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn get_claude_usage_timeline(
     state: State<'_, Arc<crate::AppState>>,
     scope: String,
@@ -1013,7 +1013,7 @@ pub async fn get_claude_usage_timeline(
 /// - `"all"` — all projects
 /// - `"current"` — current project (determined from config / active repo)
 /// - Any other string — treated as a specific project slug
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn get_claude_session_stats(
     state: State<'_, Arc<crate::AppState>>,
     scope: String,
@@ -1261,7 +1261,7 @@ pub async fn get_claude_session_stats(
 }
 
 /// List available Claude project slugs for the scope dropdown.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn get_claude_project_list() -> Result<Vec<ProjectEntry>, String> {
     let projects_dir = claude_projects_dir()
         .ok_or_else(|| "Cannot determine home directory".to_string())?;

--- a/src-tauri/src/claude_usage.rs
+++ b/src-tauri/src/claude_usage.rs
@@ -15,6 +15,7 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 // ---------------------------------------------------------------------------
@@ -958,7 +959,8 @@ pub async fn get_claude_usage_api() -> Result<UsageApiResponse, String> {
 /// Returns hourly token usage points aggregated from the session stats cache.
 /// The `scope` parameter filters which projects to include ("all" or a slug).
 /// The `days` parameter limits the time window (default 7).
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn get_claude_usage_timeline(
     state: State<'_, Arc<crate::AppState>>,
     scope: String,
@@ -1013,7 +1015,8 @@ pub async fn get_claude_usage_timeline(
 /// - `"all"` — all projects
 /// - `"current"` — current project (determined from config / active repo)
 /// - Any other string — treated as a specific project slug
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn get_claude_session_stats(
     state: State<'_, Arc<crate::AppState>>,
     scope: String,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -988,52 +988,52 @@ const ACTIVITY_FILE: &str = "activity.json";
 const AI_PROMPTS_FILE: &str = "ai-prompts.json";
 
 // App config
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_app_config() -> AppConfig {
     load_json_config(APP_CONFIG_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_app_config(config: AppConfig) -> Result<(), String> {
     save_json_config(APP_CONFIG_FILE, &config)
 }
 
 // Notification config
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_notification_config() -> NotificationConfig {
     load_json_config(NOTIFICATION_CONFIG_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_notification_config(config: NotificationConfig) -> Result<(), String> {
     save_json_config(NOTIFICATION_CONFIG_FILE, &config)
 }
 
 // UI prefs
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_ui_prefs() -> UIPrefsConfig {
     load_json_config(UI_PREFS_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_ui_prefs(config: UIPrefsConfig) -> Result<(), String> {
     save_json_config(UI_PREFS_FILE, &config)
 }
 
 // Repo settings
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_repo_settings() -> RepoSettingsMap {
     load_json_config(REPO_SETTINGS_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_repo_settings(config: RepoSettingsMap) -> Result<(), String> {
     save_json_config(REPO_SETTINGS_FILE, &config)
 }
 
 /// Set or clear a human-readable label for a branch/worktree within a repo.
 /// `label = None` removes the label. Idempotent; no-ops on unknown repo paths.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn set_branch_label(repo_path: String, branch_name: String, label: Option<String>) -> Result<(), String> {
     let mut settings: RepoSettingsMap = load_json_config(REPO_SETTINGS_FILE);
     if let Some(entry) = settings.repos.get_mut(&repo_path) {
@@ -1058,113 +1058,113 @@ pub(crate) fn remove_branch_label(repo_path: &str, branch_name: &str) {
     }
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn check_has_custom_settings(path: String) -> bool {
     let settings: RepoSettingsMap = load_json_config(REPO_SETTINGS_FILE);
     settings.repos.get(&path).is_some_and(|entry| entry.has_custom_settings())
 }
 
 // Repo local config (.tuic.json in repo root)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_repo_local_config(repo_path: String) -> Option<RepoLocalConfig> {
     load_repo_local_config_from_path(std::path::Path::new(&repo_path))
 }
 
 // Repo defaults (global defaults for all repos)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_repo_defaults() -> RepoDefaultsConfig {
     load_json_config(REPO_DEFAULTS_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_repo_defaults(config: RepoDefaultsConfig) -> Result<(), String> {
     save_json_config(REPO_DEFAULTS_FILE, &config)
 }
 
 // Repositories (opaque JSON — schema owned by frontend)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_repositories() -> serde_json::Value {
     load_json_config(REPOSITORIES_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_repositories(config: serde_json::Value) -> Result<(), String> {
     save_json_config(REPOSITORIES_FILE, &config)
 }
 
 // Pane layout (schema owned by frontend)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_pane_layout() -> serde_json::Value {
     load_json_config(PANE_LAYOUT_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_pane_layout(layout: serde_json::Value) -> Result<(), String> {
     save_json_config(PANE_LAYOUT_FILE, &layout)
 }
 
 // Prompt library
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_prompt_library() -> PromptLibraryConfig {
     load_json_config(PROMPT_LIBRARY_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_prompt_library(config: PromptLibraryConfig) -> Result<(), String> {
     save_json_config(PROMPT_LIBRARY_FILE, &config)
 }
 
 // Notes (opaque JSON — schema owned by frontend)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_notes() -> serde_json::Value {
     load_json_config(NOTES_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_notes(config: serde_json::Value) -> Result<(), String> {
     save_json_config(NOTES_FILE, &config)
 }
 
 // Activity center (opaque JSON — schema owned by frontend)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_activity() -> serde_json::Value {
     load_json_config(ACTIVITY_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_activity(items: serde_json::Value) -> Result<(), String> {
     save_json_config(ACTIVITY_FILE, &items)
 }
 
 // Keybindings (opaque JSON — schema owned by frontend)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_keybindings() -> serde_json::Value {
     load_json_config(KEYBINDINGS_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_keybindings(config: serde_json::Value) -> Result<(), String> {
     save_json_config(KEYBINDINGS_FILE, &config)
 }
 
 // Agents config
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_agents_config() -> AgentsConfig {
     load_json_config(AGENTS_CONFIG_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_agents_config(config: AgentsConfig) -> Result<(), String> {
     save_json_config(AGENTS_CONFIG_FILE, &config)
 }
 
 // AI prompts
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_ai_prompts() -> AiPromptsConfig {
     load_json_config(AI_PROMPTS_FILE)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_ai_prompts(config: AiPromptsConfig) -> Result<(), String> {
     save_json_config(AI_PROMPTS_FILE, &config)
 }
@@ -1196,7 +1196,7 @@ fn validate_note_id(note_id: &str) -> Result<(), String> {
 
 /// Save a base64-encoded image to `config_dir()/note-images/<note_id>/<timestamp>.<extension>`.
 /// Returns the absolute path of the saved file.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_note_image(
     note_id: String,
     data_base64: String,
@@ -1246,7 +1246,7 @@ pub(crate) fn save_note_image(
 }
 
 /// Delete all image assets for a note. No-op if the directory doesn't exist.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn delete_note_assets(note_id: String) -> Result<(), String> {
     validate_note_id(&note_id)?;
 
@@ -1259,7 +1259,7 @@ pub(crate) fn delete_note_assets(note_id: String) -> Result<(), String> {
 }
 
 /// Delete image assets for multiple notes in a single IPC round-trip.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn delete_note_assets_batch(note_ids: Vec<String>) -> Result<(), String> {
     let base = config_dir().join(NOTE_IMAGES_DIR);
     for note_id in &note_ids {
@@ -1275,7 +1275,7 @@ pub(crate) fn delete_note_assets_batch(note_ids: Vec<String>) -> Result<(), Stri
 
 /// Return the absolute path of the note-images root directory.
 /// The frontend needs this as `baseDir` for `convertFileSrc()`.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_note_images_dir() -> String {
     config_dir()
         .join(NOTE_IMAGES_DIR)

--- a/src-tauri/src/dictation/commands.rs
+++ b/src-tauri/src/dictation/commands.rs
@@ -37,6 +37,7 @@ impl Drop for ProcessingGuard {
     }
 }
 
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::app_logger;

--- a/src-tauri/src/dictation/fn_key_monitor.rs
+++ b/src-tauri/src/dictation/fn_key_monitor.rs
@@ -14,6 +14,7 @@ pub fn install(app_handle: tauri::AppHandle) {
     use objc2_app_kit::{NSEvent, NSEventMask, NSEventModifierFlags};
     use std::ptr::NonNull;
     use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "desktop")]
     use tauri::Emitter;
 
     let fn_was_down = AtomicBool::new(false);

--- a/src-tauri/src/diff_triage.rs
+++ b/src-tauri/src/diff_triage.rs
@@ -944,7 +944,7 @@ fn emit_progress(
     );
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn run_diff_triage(
     app: tauri::AppHandle,
     repo_path: String,

--- a/src-tauri/src/diff_triage.rs
+++ b/src-tauri/src/diff_triage.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+#[cfg(feature = "desktop")]
 use tauri::Emitter;
 
 // ---------------------------------------------------------------------------
@@ -800,6 +801,7 @@ async fn do_turn(
     None
 }
 
+#[cfg(feature = "desktop")]
 /// Multi-turn LLM classification: overview turn + per-file turns with tool use.
 /// Skips unchanged files (hash match). Updates session in place.
 #[allow(clippy::too_many_arguments)]
@@ -908,6 +910,7 @@ async fn classify_multi_turn(
 }
 
 
+#[cfg(feature = "desktop")]
 #[derive(Debug, Clone, Serialize)]
 struct TriageProgress {
     repo_path: String,
@@ -919,6 +922,7 @@ struct TriageProgress {
     llm_model: Option<String>,
 }
 
+#[cfg(feature = "desktop")]
 #[allow(clippy::too_many_arguments)]
 fn emit_progress(
     app: &tauri::AppHandle,
@@ -944,7 +948,8 @@ fn emit_progress(
     );
 }
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub(crate) async fn run_diff_triage(
     app: tauri::AppHandle,
     repo_path: String,

--- a/src-tauri/src/dir_watcher.rs
+++ b/src-tauri/src/dir_watcher.rs
@@ -124,8 +124,8 @@ mod tests {
         assert!(result.unwrap_err().contains("does not exist"));
     }
 
-    #[test]
-    fn test_watcher_stops_on_drop() {
+    #[tokio::test]
+    async fn test_watcher_stops_on_drop() {
         let tmp = TempDir::new().unwrap();
         let dir_path = tmp.path().to_str().unwrap().to_string();
         let state = make_test_state();
@@ -137,24 +137,24 @@ mod tests {
         assert!(!state.dir_watchers.contains_key(&dir_path));
     }
 
-    #[test]
-    fn test_replace_watcher() {
+    #[tokio::test]
+    async fn test_replace_watcher() {
         let tmp1 = TempDir::new().unwrap();
         let tmp2 = TempDir::new().unwrap();
         let path1 = tmp1.path().to_str().unwrap().to_string();
         let path2 = tmp2.path().to_str().unwrap().to_string();
         let state = make_test_state();
 
-        start_watching(&path1, None, &state).unwrap();
+        start_watching(&path1, &state).unwrap();
         assert!(state.dir_watchers.contains_key(&path1));
 
         // Starting a new path doesn't affect the old one
-        start_watching(&path2, None, &state).unwrap();
+        start_watching(&path2, &state).unwrap();
         assert!(state.dir_watchers.contains_key(&path1));
         assert!(state.dir_watchers.contains_key(&path2));
 
         // Re-watching the same path replaces the watcher (no error, no double entry)
-        start_watching(&path1, None, &state).unwrap();
+        start_watching(&path1, &state).unwrap();
         assert_eq!(state.dir_watchers.len(), 2);
     }
 

--- a/src-tauri/src/dir_watcher.rs
+++ b/src-tauri/src/dir_watcher.rs
@@ -99,13 +99,13 @@ pub(crate) fn stop_watching(dir_path: &str, state: &Arc<AppState>) {
 
 // --- Tauri commands ---
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn start_dir_watcher(path: String, app_handle: AppHandle) -> Result<(), String> {
     let state = app_handle.state::<Arc<AppState>>();
     start_watching(&path, Some(&app_handle), &state)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn stop_dir_watcher(path: String, app_handle: AppHandle) {
     let state = app_handle.state::<Arc<AppState>>();
     stop_watching(&path, &state);

--- a/src-tauri/src/dir_watcher.rs
+++ b/src-tauri/src/dir_watcher.rs
@@ -3,6 +3,7 @@ use parking_lot::Mutex;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::state::AppEvent;
@@ -22,7 +23,6 @@ pub(crate) struct DirChangedPayload {
 /// Emits `"dir-changed"` when files are created, deleted, or renamed.
 pub(crate) fn start_watching(
     dir_path: &str,
-    app_handle: Option<&AppHandle>,
     state: &Arc<AppState>,
 ) -> Result<(), String> {
     let path = PathBuf::from(dir_path);
@@ -34,9 +34,10 @@ pub(crate) fn start_watching(
     state.dir_watchers.remove(dir_path);
 
     let dir_path_owned = dir_path.to_string();
-    let handle = app_handle.cloned();
+    #[cfg(feature = "desktop")]
+    let handle = state.app_handle.read().clone();
     let event_bus = state.event_bus.clone();
-    let rt = tauri::async_runtime::handle().inner().clone();
+    let rt = tokio::runtime::Handle::current();
     let pending: Arc<Mutex<Option<tokio::task::AbortHandle>>> = Arc::new(Mutex::new(None));
 
     let mut watcher = notify::recommended_watcher(
@@ -44,16 +45,7 @@ pub(crate) fn start_watching(
             let _event = match result {
                 Ok(e) => e,
                 Err(err) => {
-                    if let Some(ref handle) = handle {
-                        crate::app_logger::log_via_handle(
-                            handle,
-                            "warn",
-                            "app",
-                            &format!("[dir_watcher] watcher error for {dir_path_owned}: {err}"),
-                        );
-                    } else {
-                        tracing::warn!(source = "dir_watcher", path = %dir_path_owned, "Watcher error: {err}");
-                    }
+                    tracing::warn!(source = "dir_watcher", path = %dir_path_owned, "Watcher error: {err}");
                     return;
                 }
             };
@@ -61,6 +53,7 @@ pub(crate) fn start_watching(
             // Trailing debounce: cancel previous timer, start new one
             let dir_path = dir_path_owned.clone();
             let bus = event_bus.clone();
+            #[cfg(feature = "desktop")]
             let h = handle.clone();
             let mut guard = pending.lock();
             if let Some(prev) = guard.take() {
@@ -71,6 +64,7 @@ pub(crate) fn start_watching(
                 let _ = bus.send(AppEvent::DirChanged {
                     dir_path: dir_path.clone(),
                 });
+                #[cfg(feature = "desktop")]
                 if let Some(ref handle) = h {
                     let _ = handle.emit(
                         "dir-changed",
@@ -99,13 +93,15 @@ pub(crate) fn stop_watching(dir_path: &str, state: &Arc<AppState>) {
 
 // --- Tauri commands ---
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub(crate) fn start_dir_watcher(path: String, app_handle: AppHandle) -> Result<(), String> {
     let state = app_handle.state::<Arc<AppState>>();
-    start_watching(&path, Some(&app_handle), &state)
+    start_watching(&path, &state)
 }
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub(crate) fn stop_dir_watcher(path: String, app_handle: AppHandle) {
     let state = app_handle.state::<Arc<AppState>>();
     stop_watching(&path, &state);
@@ -123,7 +119,7 @@ mod tests {
     #[test]
     fn test_watch_nonexistent_dir_returns_error() {
         let state = make_test_state();
-        let result = start_watching("/tmp/nonexistent-dir-watcher-test-12345", None, &state);
+        let result = start_watching("/tmp/nonexistent-dir-watcher-test-12345", &state);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("does not exist"));
     }
@@ -134,7 +130,7 @@ mod tests {
         let dir_path = tmp.path().to_str().unwrap().to_string();
         let state = make_test_state();
 
-        start_watching(&dir_path, None, &state).unwrap();
+        start_watching(&dir_path, &state).unwrap();
         assert!(state.dir_watchers.contains_key(&dir_path));
 
         stop_watching(&dir_path, &state);

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -241,13 +241,13 @@ pub(crate) fn stat_path_impl(path: String) -> PathStat {
 }
 
 /// Stat an absolute path — returns existence and directory flag without leaking errors.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn stat_path(path: String) -> PathStat {
     stat_path_impl(path)
 }
 
 /// List entries in a directory within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn list_directory(repo_path: String, subdir: String) -> Result<Vec<DirEntry>, String> {
     list_directory_impl(repo_path, subdir)
 }
@@ -376,7 +376,7 @@ pub(crate) fn list_directory_impl(repo_path: String, subdir: String) -> Result<V
 /// Recursively search files in a repository matching a glob-like query.
 /// Returns up to `limit` results (default 200) to avoid blowing up on huge repos.
 /// Respects .gitignore natively via the `ignore` crate (no subprocess).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn search_files(
     app_state: tauri::State<'_, std::sync::Arc<crate::state::AppState>>,
     repo_path: String,
@@ -387,7 +387,7 @@ pub async fn search_files(
     search_files_impl(repo_path, query, limit)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 #[allow(clippy::too_many_arguments)]
 pub async fn search_content(
     app: tauri::AppHandle,
@@ -896,13 +896,13 @@ fn build_search_pattern(query: &str) -> regex::Regex {
 
 /// Read a file's content within a repository.
 /// Re-uses the existing `read_file_impl` from lib.rs.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn fs_read_file(repo_path: String, file: String) -> Result<String, String> {
     crate::read_file_impl(repo_path, file)
 }
 
 /// Write content to a file within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn write_file(repo_path: String, file: String, content: String) -> Result<(), String> {
     let (_canonical_repo, canonical_target) = if PathBuf::from(&repo_path).join(&file).exists() {
         validate_path(&repo_path, &file)?
@@ -915,7 +915,7 @@ pub fn write_file(repo_path: String, file: String, content: String) -> Result<()
 }
 
 /// Create a directory (and parents) within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn create_directory(repo_path: String, dir: String) -> Result<(), String> {
     let repo = PathBuf::from(&repo_path);
     let target = repo.join(&dir);
@@ -947,7 +947,7 @@ pub fn create_directory(repo_path: String, dir: String) -> Result<(), String> {
 }
 
 /// Delete a file or directory within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn delete_path(repo_path: String, path: String) -> Result<(), String> {
     let (_canonical_repo, canonical_target) = validate_path(&repo_path, &path)?;
 
@@ -961,7 +961,7 @@ pub fn delete_path(repo_path: String, path: String) -> Result<(), String> {
 }
 
 /// Rename/move a file or directory within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn rename_path(
     repo_path: String,
     from: String,
@@ -979,7 +979,7 @@ pub fn rename_path(
 }
 
 /// Copy a file within a repository.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn copy_path(
     repo_path: String,
     from: String,
@@ -1057,7 +1057,7 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::
 /// directory, the function performs no filesystem operations and returns
 /// `needs_confirm=true`. When `allow_recursive=true`, directories are moved
 /// via rename (or copy+remove on cross-device) or copied recursively.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn fs_transfer_paths(
     dest_dir: String,
     paths: Vec<String>,
@@ -1236,7 +1236,7 @@ fn is_tcc_protected_path(path: &std::path::Path) -> bool {
 ///
 /// SAFETY: Refuses to probe macOS TCC-protected directories to avoid
 /// triggering system permission dialogs.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn resolve_terminal_path(cwd: String, candidate: String) -> Option<ResolvedFilePath> {
     let path_str = strip_line_col_suffix(&candidate);
 
@@ -1274,7 +1274,7 @@ pub fn resolve_terminal_path(cwd: String, candidate: String) -> Option<ResolvedF
 }
 
 /// Append a path pattern to the repo's .gitignore file.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn add_to_gitignore(repo_path: String, pattern: String) -> Result<(), String> {
     let repo = PathBuf::from(&repo_path);
     let canonical_repo = repo

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "desktop")]
 use tauri::Emitter;
 
 /// A directory entry returned by `list_directory`.
@@ -376,7 +377,8 @@ pub(crate) fn list_directory_impl(repo_path: String, subdir: String) -> Result<V
 /// Recursively search files in a repository matching a glob-like query.
 /// Returns up to `limit` results (default 200) to avoid blowing up on huge repos.
 /// Respects .gitignore natively via the `ignore` crate (no subprocess).
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn search_files(
     app_state: tauri::State<'_, std::sync::Arc<crate::state::AppState>>,
     repo_path: String,
@@ -387,7 +389,8 @@ pub async fn search_files(
     search_files_impl(repo_path, query, limit)
 }
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn search_content(
     app: tauri::AppHandle,
@@ -423,7 +426,7 @@ pub async fn search_content(
     let throttle_guard = app_state.indexer_throttle.begin_search();
 
     // Run search in blocking thread
-    tauri::async_runtime::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
         let _throttle_guard = throttle_guard;
         match search_content_indexed(
             &index_arc, repo_path, query, case_sensitive, use_regex, whole_word, limit,

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -4,6 +4,7 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::git_cli::git_cmd;
@@ -162,6 +163,7 @@ pub(crate) fn get_repo_info_impl(path: &str) -> RepoInfo {
 }
 
 /// Get git repository info for a path (cached, 5s TTL)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_info(state: State<'_, Arc<AppState>>, path: String) -> Result<RepoInfo, String> {
     if let Some(cached) = AppState::get_cached(&state.git_cache.repo_info, &path, GIT_CACHE_TTL) {
@@ -178,7 +180,7 @@ pub(crate) async fn get_repo_info(state: State<'_, Arc<AppState>>, path: String)
 }
 
 /// Get the origin remote URL for a repository (returns None if not a git repo or no remote).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_remote_url(path: String) -> Result<Option<String>, String> {
     tokio::task::spawn_blocking(move || read_remote_url(Path::new(&path)))
         .await
@@ -228,6 +230,7 @@ pub(crate) fn rename_branch_impl(path: &str, old_name: &str, new_name: &str) -> 
 }
 
 /// Rename a git branch (Tauri command with cache invalidation)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn rename_branch(state: State<'_, Arc<AppState>>, path: String, old_name: String, new_name: String) -> Result<(), String> {
     let state_arc = state.inner().clone();
@@ -288,6 +291,7 @@ pub(crate) fn create_branch_impl(path: &str, name: &str, start_point: Option<&st
 }
 
 /// Create a git branch (Tauri command with cache invalidation)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn create_branch(state: State<'_, Arc<AppState>>, path: String, name: String, start_point: Option<String>, checkout: bool) -> Result<(), String> {
     let state_arc = state.inner().clone();
@@ -301,7 +305,7 @@ pub(crate) async fn create_branch(state: State<'_, Arc<AppState>>, path: String,
 }
 
 /// Read the stored base ref for a branch (Tauri command).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_branch_base(path: String, branch_name: String) -> Result<Option<String>, String> {
     tokio::task::spawn_blocking(move || crate::worktree::get_branch_base(&path, &branch_name))
         .await
@@ -312,6 +316,7 @@ pub(crate) async fn get_branch_base(path: String, branch_name: String) -> Result
 ///
 /// Reads `branch.<name>.tuicommander-base` from git config, fetches if remote,
 /// then applies the chosen strategy. On conflict, aborts and returns error.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn update_from_base(
     state: State<'_, Arc<AppState>>,
@@ -417,6 +422,7 @@ pub(crate) fn delete_branch_impl(path: &str, name: &str, force: bool) -> Result<
 }
 
 /// Delete a git branch (Tauri command with cache invalidation)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn delete_branch(state: State<'_, Arc<AppState>>, path: String, name: String, force: bool) -> Result<DeleteBranchResult, String> {
     let state_arc = state.inner().clone();
@@ -438,7 +444,7 @@ pub(crate) struct RecentCommit {
 }
 
 /// Get the N most recent commits
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_recent_commits(path: String, count: Option<u32>) -> Result<Vec<RecentCommit>, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -485,7 +491,7 @@ fn diff_base_args(scope: &Option<String>) -> Result<Vec<String>, String> {
 }
 
 /// Get git diff for a repository
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_git_diff(path: String, scope: Option<String>) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -575,7 +581,7 @@ fn split_diff_output(output: &str, result: &mut HashMap<String, String>) {
 }
 
 /// Get diff stats (additions/deletions) for a repository
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 /// Sync implementation of diff stats retrieval.
 pub(crate) fn get_diff_stats_impl(path: &str, scope: Option<&str>) -> DiffStats {
     let repo_path = PathBuf::from(path);
@@ -611,7 +617,7 @@ pub(crate) fn get_diff_stats_impl(path: &str, scope: Option<&str>) -> DiffStats 
     DiffStats { additions: 0, deletions: 0 }
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_diff_stats(path: String, scope: Option<String>) -> Result<DiffStats, String> {
     tokio::task::spawn_blocking(move || get_diff_stats_impl(&path, scope.as_deref()))
         .await
@@ -619,7 +625,7 @@ pub(crate) async fn get_diff_stats(path: String, scope: Option<String>) -> Resul
 }
 
 /// Get list of changed files with status and stats
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_changed_files(path: String, scope: Option<String>) -> Result<Vec<ChangedFile>, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -731,7 +737,7 @@ const NULL_DEVICE: &str = "NUL";
 /// Get diff for a single file.
 /// When `untracked` is `Some(true)`, skip the `ls-files` probe and go directly
 /// to `--no-index` diff (the frontend already knows the file status).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_file_diff(path: String, file: String, scope: Option<String>, untracked: Option<bool>) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -817,7 +823,7 @@ pub(crate) fn get_repo_initials(name: &str) -> String {
 }
 
 /// Generate initials from a repository name (Tauri command)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_initials(name: String) -> String {
     get_repo_initials(&name)
 }
@@ -832,7 +838,7 @@ pub(crate) fn is_main_branch(branch_name: &str) -> bool {
 }
 
 /// Check if a branch name is a main/primary branch (Tauri command)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn check_is_main_branch(branch: String) -> bool {
     is_main_branch(&branch)
 }
@@ -938,6 +944,7 @@ fn packed_ref_exists(git_dir: &Path, ref_name: &str) -> bool {
 }
 
 /// Tauri command: get branches merged into the main branch (cached, 5s TTL)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_merged_branches(
     state: State<'_, Arc<AppState>>,
@@ -1076,6 +1083,7 @@ pub(crate) async fn get_repo_summary_impl(state: &AppState, repo_path: String) -
 }
 
 /// Single IPC replacement for the N+2 calls in refreshAllBranchStats.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_summary(
     state: State<'_, Arc<AppState>>,
@@ -1113,6 +1121,7 @@ pub(crate) async fn get_repo_structure_impl(state: &AppState, repo_path: String)
     Ok(RepoStructure { worktree_paths, merged_branches })
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_structure(
     state: State<'_, Arc<AppState>>,
@@ -1163,6 +1172,7 @@ pub(crate) async fn get_repo_diff_stats_impl(_state: &AppState, repo_path: Strin
     Ok(RepoDiffStats { diff_stats, last_commit_ts })
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_diff_stats(
     state: State<'_, Arc<AppState>>,
@@ -1172,7 +1182,7 @@ pub(crate) async fn get_repo_diff_stats(
 }
 
 /// Get git branches for a repository (Story 052)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_git_branches(path: String) -> Result<Vec<serde_json::Value>, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -1359,6 +1369,7 @@ fn parse_track_value(track: &str, key: &str) -> Option<u32> {
 }
 
 /// Get rich branch details for a repository (cached, 5s TTL).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_branches_detail(
     state: State<'_, Arc<AppState>>,
@@ -1413,7 +1424,7 @@ pub(crate) fn get_recent_branches_impl(path: &Path, limit: usize) -> Result<Vec<
 }
 
 /// Get recently checked-out branch names for a repository (most recent first).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_recent_branches(path: String, limit: Option<usize>) -> Result<Vec<String>, String> {
     tokio::task::spawn_blocking(move || get_recent_branches_impl(Path::new(&path), limit.unwrap_or(5)))
         .await
@@ -1577,6 +1588,7 @@ pub(crate) fn get_git_panel_context_impl(path: &Path) -> GitPanelContext {
 }
 
 /// Get rich git panel context in a single IPC call (cached, 5s TTL).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_git_panel_context(
     state: State<'_, Arc<AppState>>,
@@ -1658,6 +1670,7 @@ exit /b 1
 /// Used by the sidebar Git Quick Actions (pull, push, fetch, stash).
 /// Async so network operations (pull/push/fetch) don't block the IPC thread.
 /// Sets SSH_ASKPASS so passphrase prompts show a native GUI dialog.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn run_git_command(
     state: State<'_, Arc<AppState>>,
@@ -1871,7 +1884,7 @@ pub(crate) fn enrich_with_numstat(repo_path: &Path, entries: &mut [StatusEntry],
 }
 
 /// Get full working tree status from porcelain v2 output.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_working_tree_status(path: String) -> Result<WorkingTreeStatus, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -1936,7 +1949,7 @@ fn validate_paths_within_repo(repo_path: &Path, files: &[String]) -> Result<(), 
 }
 
 /// Stage files (`git add -- <files>`).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_stage_files(path: String, files: Vec<String>) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -1955,7 +1968,7 @@ pub(crate) async fn git_stage_files(path: String, files: Vec<String>) -> Result<
 }
 
 /// Unstage files (`git restore --staged -- <files>`).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_unstage_files(path: String, files: Vec<String>) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -1974,7 +1987,7 @@ pub(crate) async fn git_unstage_files(path: String, files: Vec<String>) -> Resul
 }
 
 /// Discard working tree changes (`git restore -- <files>`). Destructive!
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_discard_files(path: String, files: Vec<String>) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2001,7 +2014,7 @@ pub(crate) async fn git_discard_files(path: String, files: Vec<String>) -> Resul
 ///
 /// The `patch` must be a valid unified diff (starting with `diff --git` or `---`).
 /// Pipe the patch via stdin to avoid temp files.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_apply_reverse_patch(path: String, patch: String, scope: Option<String>) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2059,7 +2072,7 @@ pub(crate) async fn git_apply_reverse_patch(path: String, patch: String, scope: 
 // --- git commit ---
 
 /// Commit staged changes and return the new commit hash.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_commit(path: String, message: String, amend: Option<bool>) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2168,7 +2181,7 @@ pub(crate) fn get_commit_log_impl(path: String, count: Option<u32>, after: Optio
 }
 
 /// Get paginated commit log with full metadata.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_commit_log(
     path: String,
     count: Option<u32>,
@@ -2189,7 +2202,7 @@ pub(crate) struct StashEntry {
 }
 
 /// List all stash entries.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_stash_list(path: String) -> Result<Vec<StashEntry>, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2249,7 +2262,7 @@ fn validate_stash_ref(stash_ref: &str) -> Result<(), String> {
 }
 
 /// Apply a stash without removing it.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_stash_apply(path: String, stash_ref: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2265,7 +2278,7 @@ pub(crate) async fn git_stash_apply(path: String, stash_ref: String) -> Result<(
 }
 
 /// Apply and remove a stash.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_stash_pop(path: String, stash_ref: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2281,7 +2294,7 @@ pub(crate) async fn git_stash_pop(path: String, stash_ref: String) -> Result<(),
 }
 
 /// Drop (delete) a stash.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_stash_drop(path: String, stash_ref: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2297,7 +2310,7 @@ pub(crate) async fn git_stash_drop(path: String, stash_ref: String) -> Result<()
 }
 
 /// Show diff for a stash entry.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn git_stash_show(path: String, stash_ref: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let repo_path = PathBuf::from(&path);
@@ -2313,7 +2326,7 @@ pub(crate) async fn git_stash_show(path: String, stash_ref: String) -> Result<St
 }
 
 /// Get commit log for a specific file, following renames.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_file_history(
     path: String,
     file: String,
@@ -2428,7 +2441,7 @@ fn parse_blame_porcelain(output: &str) -> Vec<BlameLine> {
 }
 
 /// Get per-line blame information for a file.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_file_blame(
     path: String,
     file: String,

--- a/src-tauri/src/git_graph.rs
+++ b/src-tauri/src/git_graph.rs
@@ -214,7 +214,7 @@ fn assign_lanes(commits: &[RawCommit]) -> Vec<GraphNode> {
 // Tauri command
 // ---------------------------------------------------------------------------
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn get_commit_graph(path: String, count: Option<u32>) -> Result<Vec<GraphNode>, String> {
     tokio::task::spawn_blocking(move || {
         let count = count.unwrap_or(200).min(1000);

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::error_classification::calculate_backoff_delay;
@@ -1058,6 +1059,7 @@ pub(crate) async fn get_all_batch_impl(
 }
 
 /// Fetch issues for a single repo (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_issues(
     state: State<'_, Arc<AppState>>,
@@ -1071,6 +1073,7 @@ pub(crate) async fn get_repo_issues(
 }
 
 /// Fetch issues for multiple repos (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_all_issues(
     state: State<'_, Arc<AppState>>,
@@ -1118,6 +1121,7 @@ pub(crate) async fn close_issue_impl(
 }
 
 /// Close a GitHub issue (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn close_issue(
     repo_path: String,
@@ -1165,6 +1169,7 @@ pub(crate) async fn reopen_issue_impl(
 }
 
 /// Reopen a GitHub issue (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn reopen_issue(
     repo_path: String,
@@ -1295,6 +1300,7 @@ pub(crate) async fn get_repo_pr_statuses_impl(
 }
 
 /// Get PR statuses for a repository (cached, 30s TTL).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_repo_pr_statuses(
     state: State<'_, Arc<AppState>>,
@@ -1389,6 +1395,7 @@ pub(crate) async fn get_all_pr_statuses_impl(
 /// Fetch PR statuses for all repos in a single batched GraphQL call.
 /// On failure, the frontend should retry with per-repo individual calls.
 /// `include_merged` is true for the startup poll to detect offline transitions.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_all_pr_statuses(
     state: State<'_, Arc<AppState>>,
@@ -1505,6 +1512,7 @@ pub(crate) async fn filter_changed_repos(
 }
 
 /// Tauri command wrapper — cached with GIT_CACHE_TTL to avoid spawning git subprocesses every poll.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_github_status(
     path: String,
@@ -1525,6 +1533,7 @@ pub(crate) async fn get_github_status(
 
 /// Check if the GitHub API circuit breaker is open (rate-limited or failure-based).
 /// Returns Ok(true) if requests are allowed, Ok(false) if blocked.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn check_github_circuit(
     state: State<'_, Arc<AppState>>,
@@ -1683,6 +1692,7 @@ pub(crate) async fn merge_pr_github_impl(
 
 /// Merge a PR via GitHub REST API (Tauri command).
 /// Supports merge_method: "merge", "squash", "rebase".
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn merge_pr_via_github(
     repo_path: String,
@@ -1695,6 +1705,7 @@ pub(crate) async fn merge_pr_via_github(
 }
 
 /// Get CI check details for a PR via GitHub GraphQL API (Story 060).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_ci_checks(
     path: String,
@@ -1752,6 +1763,7 @@ pub(crate) async fn approve_pr_impl(
 }
 
 /// Approve a PR via GitHub REST API (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn approve_pr(
     repo_path: String,
@@ -1897,7 +1909,7 @@ fn fetch_ci_failure_logs_impl(repo_path: &str, branch: &str) -> Result<String, S
 }
 
 /// Tauri command: fetch CI failure logs for the latest failed run on a branch.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn fetch_ci_failure_logs(
     repo_path: String,
     branch: String,
@@ -1909,6 +1921,7 @@ pub(crate) async fn fetch_ci_failure_logs(
 }
 
 /// Fetch PR diff via GitHub REST API (Tauri command).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn get_pr_diff(
     repo_path: String,

--- a/src-tauri/src/github_auth.rs
+++ b/src-tauri/src/github_auth.rs
@@ -7,6 +7,8 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "desktop")]
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::state::AppState;
@@ -191,6 +193,7 @@ pub(crate) async fn poll_device_flow(
 
 /// Start a Device Flow login. Returns the device code and user code
 /// for display in the UI.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_start_login(
     state: State<'_, Arc<AppState>>,
@@ -201,6 +204,7 @@ pub(crate) async fn github_start_login(
 /// Poll GitHub for the Device Flow token. The frontend calls this repeatedly
 /// with the interval from `github_start_login`. On success, the token is saved
 /// to the OS keyring and activated in AppState.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_poll_login(
     state: State<'_, Arc<AppState>>,
@@ -236,6 +240,7 @@ pub(crate) async fn github_poll_login(
 
 /// Log out of GitHub OAuth. Deletes the token from keyring and clears
 /// the runtime state. Falls back to env/gh CLI tokens if available.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_logout(
     state: State<'_, Arc<AppState>>,
@@ -258,6 +263,7 @@ pub(crate) async fn github_logout(
 /// Disconnect from GitHub entirely, clearing the runtime token regardless
 /// of source. Does NOT delete env vars or gh CLI config — only clears the
 /// in-memory token so the app stops using it until restart or re-login.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_disconnect(
     state: State<'_, Arc<AppState>>,
@@ -291,6 +297,7 @@ pub(crate) struct GitHubDiagnostics {
 }
 
 /// Get GitHub integration diagnostics for the settings UI.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_diagnostics(
     state: State<'_, Arc<AppState>>,
@@ -323,6 +330,7 @@ pub(crate) async fn github_diagnostics(
 
 /// Get the current GitHub authentication status, including the user's
 /// login name if authenticated.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_auth_status(
     state: State<'_, Arc<AppState>>,

--- a/src-tauri/src/github_poller.rs
+++ b/src-tauri/src/github_poller.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
 
@@ -359,6 +360,7 @@ fn process_repo_update(
 // Tauri commands
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_start_polling(
     state: tauri::State<'_, Arc<AppState>>,
@@ -382,6 +384,7 @@ pub(crate) async fn github_start_polling(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_stop_polling(
     state: tauri::State<'_, Arc<AppState>>,
@@ -393,6 +396,7 @@ pub(crate) async fn github_stop_polling(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_set_visibility(
     state: tauri::State<'_, Arc<AppState>>,
@@ -404,6 +408,7 @@ pub(crate) async fn github_set_visibility(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_poll_repo(
     state: tauri::State<'_, Arc<AppState>>,
@@ -415,6 +420,7 @@ pub(crate) async fn github_poll_repo(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_update_paths(
     state: tauri::State<'_, Arc<AppState>>,
@@ -426,6 +432,7 @@ pub(crate) async fn github_update_paths(
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn github_set_issue_filter(
     state: tauri::State<'_, Arc<AppState>>,

--- a/src-tauri/src/github_poller.rs
+++ b/src-tauri/src/github_poller.rs
@@ -118,6 +118,7 @@ pub(crate) struct GitHubPoller {
 }
 
 impl GitHubPoller {
+    #[cfg(feature = "desktop")]
     pub(crate) fn start(state: Arc<AppState>, handle: AppHandle) -> Self {
         let (tx, rx) = mpsc::channel(32);
         tokio::spawn(poll_loop(state, handle, rx));
@@ -125,9 +126,11 @@ impl GitHubPoller {
     }
 }
 
+#[cfg(feature = "desktop")]
 /// Per-repo previous PR state for transition comparison.
 type PrevState = HashMap<String, HashMap<String, BranchPrStatus>>;
 
+#[cfg(feature = "desktop")]
 struct PollMutableState {
     prev: PrevState,
     fail_count: u32,
@@ -135,6 +138,7 @@ struct PollMutableState {
     etag_cache: HashMap<String, String>,
 }
 
+#[cfg(feature = "desktop")]
 async fn poll_loop(
     state: Arc<AppState>,
     handle: AppHandle,
@@ -270,6 +274,7 @@ fn current_interval(visible: bool, fail_count: u32, rate_budget: u32) -> Duratio
     Duration::from_millis(backoff.min(MAX_INTERVAL.as_millis() as f64) as u64)
 }
 
+#[cfg(feature = "desktop")]
 /// Execute a unified batch poll (PRs + Issues) and emit Tauri events for both.
 async fn poll_batch(
     state: &AppState,
@@ -323,6 +328,7 @@ async fn poll_batch(
     }
 }
 
+#[cfg(feature = "desktop")]
 /// Process PR updates for a single repo. Returns `true` if any PR data changed.
 fn process_repo_update(
     state: &AppState,

--- a/src-tauri/src/global_hotkey.rs
+++ b/src-tauri/src/global_hotkey.rs
@@ -7,7 +7,9 @@
 use anyhow::Result;
 use std::str::FromStr;
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::Manager;
+#[cfg(feature = "desktop")]
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
 use crate::state::AppState;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -846,96 +846,14 @@ pub fn run() {
         tracing::info!(source = "github", "No GitHub token from env/CLI — keychain deferred until first use");
     }
 
-    let mcp_upstream_registry_arc = Arc::new(mcp_proxy::registry::UpstreamRegistry::new());
-
     let data_dir = config::config_dir();
 
-    let state = Arc::new(AppState {
-        sessions: DashMap::new(),
-        data_dir,
-        worktrees_dir,
-        metrics: SessionMetrics::new(),
-        output_buffers: DashMap::new(),
-        mcp_sessions: DashMap::new(),
-        ws_clients: DashMap::new(),
-        config: parking_lot::RwLock::new(config.clone()),
-        git_cache: crate::state::GitCacheState::new(),
-        repo_watchers: DashMap::new(),
-        dir_watchers: DashMap::new(),
-        http_client: reqwest::Client::new(),
-        github_token: parking_lot::RwLock::new(github_token),
-        github_token_source: parking_lot::RwLock::new(github_token_source),
-        github_circuit_breaker: crate::github::GitHubCircuitBreaker::new(),
-        github_poller: parking_lot::Mutex::new(None),
-        github_viewer_login: parking_lot::RwLock::new(None),
-        server_shutdown: parking_lot::Mutex::new(None),
-        ipc_started: std::sync::atomic::AtomicBool::new(false),
-        session_token: parking_lot::RwLock::new(config.session_token.clone()),
-        #[cfg(feature = "desktop")]
-        app_handle: parking_lot::RwLock::new(None),
-        plugin_watchers: DashMap::new(),
-        vt_log_buffers: DashMap::new(),
-        #[cfg(feature = "desktop")]
-        grid_channels: DashMap::new(),
-        grid_watch: DashMap::new(),
-        grid_frame_in_flight: DashMap::new(),
-        kitty_states: DashMap::new(),
-        input_buffers: DashMap::new(),
-        last_prompts: DashMap::new(),
-        silence_states: DashMap::new(),
-        claude_usage_cache: parking_lot::Mutex::new(claude_usage::load_cache_from_disk()),
-        log_buffer,
-        event_bus: tokio::sync::broadcast::channel(256).0,
-        event_counter: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-        session_states: dashmap::DashMap::new(),
-        mcp_upstream_registry: mcp_upstream_registry_arc.clone(),
-        oauth_flow_manager: Arc::new(crate::mcp_oauth::flow::OAuthFlowManager::new(
-            mcp_upstream_registry_arc.auth_semaphore.clone(),
-        )),
-        mcp_tools_changed: tokio::sync::broadcast::channel(16).0,
-        tool_search_index: Arc::new(parking_lot::RwLock::new(crate::tool_search::ToolSearchIndex::build(&[]))),
-        content_indices: DashMap::new(),
-        indexer_throttle: Arc::new(crate::content_index::IndexerThrottle::default()),
-        slash_mode: DashMap::new(),
-        last_output_ms: DashMap::new(),
-        shell_states: DashMap::new(),
-        terminal_rows: DashMap::new(),
-        exit_codes: DashMap::new(),
-        shell_state_since_ms: DashMap::new(),
-        loaded_plugins: DashMap::new(),
-        relay: crate::state::RelayState::new(),
-        peer_agents: DashMap::new(),
-        agent_inbox: DashMap::new(),
-        agent_inbox_evictions: DashMap::new(),
-        session_html_tabs: DashMap::new(),
-        mcp_to_session: DashMap::new(),
-        session_to_mcp: DashMap::new(),
-        session_parent: DashMap::new(),
-        messaging_channels: DashMap::new(),
-        session_knowledge: DashMap::new(),
-        knowledge_dirty: DashMap::new(),
-        has_osc133_integration: DashMap::new(),
-        file_sandboxes: DashMap::new(),
-        unrestricted_sessions: DashMap::new(),
-        #[cfg(unix)]
-        bound_socket_path: parking_lot::RwLock::new(std::path::PathBuf::new()),
-        tailscale_state: parking_lot::RwLock::new(tailscale::TailscaleState::NotInstalled),
-        push_store: push::PushStore::load(&config::config_dir()),
-        desktop_window_focused: std::sync::atomic::AtomicBool::new(true),
-        server_start_time: std::time::Instant::now(),
-        github_rate_limit_remaining: std::sync::atomic::AtomicU32::new(u32::MAX),
-        term_aliases: DashMap::new(),
-        term_alias_counters: DashMap::new(),
-    });
+    let mut app_state = AppState::new(data_dir, worktrees_dir, config.clone(), log_buffer);
+    *app_state.github_token.get_mut() = github_token;
+    *app_state.github_token_source.get_mut() = github_token_source;
 
-    // Wire the event bus into the upstream registry so status changes emit SSE events.
-    state.mcp_upstream_registry.set_event_bus(state.event_bus.clone());
-    // Wire the MCP tools_changed signal so upstream changes notify MCP bridge clients.
-    state.mcp_upstream_registry.set_mcp_tools_tx(state.mcp_tools_changed.clone());
-    // Wire the OAuth flow orchestrator so 401 NeedsOAuth upstreams can start a flow.
-    state
-        .mcp_upstream_registry
-        .set_oauth_flow_manager(state.oauth_flow_manager.clone());
+    let state = Arc::new(app_state);
+    state.wire_event_bus();
 
     // Always start HTTP API server (Unix socket is always on; TCP only if remote access enabled)
     // Tailscale detection + TLS provisioning happens inside the server thread (non-blocking to Tauri setup)
@@ -1585,6 +1503,58 @@ fn build_connect_url(scheme: &str, host: &str, port: u16, token: &str) -> String
         host.to_string()
     };
     format!("{scheme}://{host}:{port}/?token={token}")
+}
+
+/// Run the headless (non-desktop) server.
+/// Called by the `tuicommander-remote` binary.
+#[cfg(not(feature = "desktop"))]
+pub async fn run_headless(port: u16) -> anyhow::Result<()> {
+    let log_buffer = Arc::new(parking_lot::Mutex::new(
+        app_logger::LogRingBuffer::new(app_logger::LOG_RING_CAPACITY),
+    ));
+    app_logger::init_tracing(log_buffer.clone());
+
+    let mut app_config = config::load_app_config();
+    app_config.remote_access_enabled = true;
+    app_config.remote_access_port = port;
+    if app_config.session_token.is_empty() {
+        app_config.session_token = uuid::Uuid::new_v4().to_string();
+    }
+
+    let data_dir = config::config_dir();
+    let worktrees_dir = data_dir.join("worktrees");
+    std::fs::create_dir_all(&worktrees_dir)?;
+
+    let (github_token, github_token_source) = crate::github_auth::resolve_token_without_keychain();
+
+    let mut app_state = AppState::new(data_dir, worktrees_dir, app_config.clone(), log_buffer);
+    *app_state.github_token.get_mut() = github_token;
+    *app_state.github_token_source.get_mut() = github_token_source;
+
+    let state = Arc::new(app_state);
+    state.wire_event_bus();
+
+    AppState::spawn_session_state_accumulator(state.clone());
+    mcp_http::mcp_transport::spawn_tool_search_index_updater(state.clone());
+    pty::spawn_tombstone_sweeper(state.clone());
+    content_index::spawn_content_index_updater(state.clone());
+    ai_agent::knowledge::spawn_persist_task(state.clone());
+    ai_agent::enrichment::spawn_worker(state.clone());
+    {
+        let sched_state = state.clone();
+        tokio::spawn(async move {
+            let scheduler = ai_agent::scheduler::Scheduler::new(sched_state);
+            scheduler.run().await;
+        });
+    }
+
+    agent_mcp::ensure_mcp_configs(&app_config.disabled_mcp_agents);
+
+    tracing::info!(source = "remote", port, "Starting tuicommander-remote");
+
+    mcp_http::start_server(state, true, true, None).await;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -862,48 +862,19 @@ pub fn run() {
     // Tailscale detection + TLS provisioning happens inside the server thread (non-blocking to Tauri setup)
     {
         let remote_enabled = config.remote_access_enabled;
-        let mcp_state = state.clone();
-        let accumulator_state = state.clone();
-        let boot_registry_state = state.clone();
-        let ts_state_ref = state.clone();
+        let server_state = state.clone();
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new()
                 .expect("Failed to create tokio runtime for HTTP server");
             rt.block_on(async move {
-                // Start session state accumulator (consumes broadcast events)
-                AppState::spawn_session_state_accumulator(accumulator_state);
-
-                // Start tool search index updater (rebuilds on mcp_tools_changed)
-                crate::mcp_http::mcp_transport::spawn_tool_search_index_updater(boot_registry_state.clone());
-
-                // Start tombstone sweeper (reaps exited-session buffers after TTL)
-                crate::pty::spawn_tombstone_sweeper(boot_registry_state.clone());
-
-                // Start content index updater (rebuilds on repo-changed)
-                crate::content_index::spawn_content_index_updater(boot_registry_state.clone());
-
-                // Start session-knowledge debounced persister (flushes dirty sessions every 2s).
-                crate::ai_agent::knowledge::spawn_persist_task(boot_registry_state.clone());
-
-                // Start AI block enrichment worker (drains the opt-in queue populated
-                // at OSC 133 D markers). No-op unless the user enables the setting.
-                crate::ai_agent::enrichment::spawn_worker(boot_registry_state.clone());
-
-                // Start cron scheduler for time-triggered agent tasks
-                {
-                    let sched_state = boot_registry_state.clone();
-                    tokio::spawn(async move {
-                        let scheduler = crate::ai_agent::scheduler::Scheduler::new(sched_state);
-                        scheduler.run().await;
-                    });
-                }
+                spawn_background_tasks(&server_state);
 
                 // Detect Tailscale and provision TLS cert (async, doesn't block window render)
                 let tls_config = if remote_enabled {
                     let ts_state = tokio::task::spawn_blocking(tailscale::detect).await
                         .unwrap_or(tailscale::TailscaleState::NotInstalled);
                     tracing::info!(source = "tailscale", ?ts_state, "Tailscale detection result");
-                    *ts_state_ref.tailscale_state.write() = ts_state.clone();
+                    *server_state.tailscale_state.write() = ts_state.clone();
                     provision_tls_config(&ts_state).await
                 } else {
                     None
@@ -913,10 +884,11 @@ pub fn run() {
                 // bridge is reachable as soon as possible. Upstream connections
                 // can be slow (network timeouts, OAuth) and must not delay socket
                 // availability — that causes "MCP disconnected" in Claude Code.
-                mcp_http::start_server(mcp_state, true, remote_enabled, tls_config).await;
+                let srv_state = server_state.clone();
+                mcp_http::start_server(srv_state, true, remote_enabled, tls_config).await;
 
                 // Auto-connect saved upstream MCP servers (after socket is live)
-                crate::mcp_upstream_config::auto_connect_saved_upstreams(&boot_registry_state).await;
+                crate::mcp_upstream_config::auto_connect_saved_upstreams(&server_state).await;
             });
         });
     }
@@ -1507,6 +1479,23 @@ fn build_connect_url(scheme: &str, host: &str, port: u16, token: &str) -> String
     format!("{scheme}://{host}:{port}/?token={token}")
 }
 
+/// Spawn background tasks shared by both desktop and headless modes.
+fn spawn_background_tasks(state: &Arc<AppState>) {
+    AppState::spawn_session_state_accumulator(state.clone());
+    mcp_http::mcp_transport::spawn_tool_search_index_updater(state.clone());
+    pty::spawn_tombstone_sweeper(state.clone());
+    content_index::spawn_content_index_updater(state.clone());
+    ai_agent::knowledge::spawn_persist_task(state.clone());
+    ai_agent::enrichment::spawn_worker(state.clone());
+    {
+        let sched_state = state.clone();
+        tokio::spawn(async move {
+            let scheduler = ai_agent::scheduler::Scheduler::new(sched_state);
+            scheduler.run().await;
+        });
+    }
+}
+
 /// Run the headless (non-desktop) server.
 /// Called by the `tuicommander-remote` binary.
 #[cfg(not(feature = "desktop"))]
@@ -1518,7 +1507,22 @@ pub async fn run_headless(port: u16) -> anyhow::Result<()> {
 
     let mut app_config = config::load_app_config();
     app_config.remote_access_enabled = true;
-    app_config.remote_access_port = port;
+    if app_config.remote_access_port != port {
+        tracing::info!(
+            source = "remote",
+            config_port = app_config.remote_access_port,
+            override_port = port,
+            "Port overridden by TUIC_PORT / CLI argument"
+        );
+        app_config.remote_access_port = port;
+    }
+    if app_config.lan_auth_bypass {
+        tracing::warn!(
+            source = "remote",
+            "lan_auth_bypass is not supported in headless mode — forcing off"
+        );
+        app_config.lan_auth_bypass = false;
+    }
     if app_config.session_token.is_empty() {
         app_config.session_token = uuid::Uuid::new_v4().to_string();
     }
@@ -1536,25 +1540,22 @@ pub async fn run_headless(port: u16) -> anyhow::Result<()> {
     let state = Arc::new(app_state);
     state.wire_event_bus();
 
-    AppState::spawn_session_state_accumulator(state.clone());
-    mcp_http::mcp_transport::spawn_tool_search_index_updater(state.clone());
-    pty::spawn_tombstone_sweeper(state.clone());
-    content_index::spawn_content_index_updater(state.clone());
-    ai_agent::knowledge::spawn_persist_task(state.clone());
-    ai_agent::enrichment::spawn_worker(state.clone());
-    {
-        let sched_state = state.clone();
-        tokio::spawn(async move {
-            let scheduler = ai_agent::scheduler::Scheduler::new(sched_state);
-            scheduler.run().await;
-        });
-    }
+    spawn_background_tasks(&state);
 
     agent_mcp::ensure_mcp_configs(&app_config.disabled_mcp_agents);
 
     tracing::info!(source = "remote", port, "Starting tuicommander-remote");
 
-    mcp_http::start_server(state, true, true, None).await;
+    // Run server until SIGINT/SIGTERM, then shut down gracefully.
+    tokio::select! {
+        _ = mcp_http::start_server(state.clone(), true, true, None) => {}
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!(source = "remote", "Received shutdown signal");
+            if let Some(tx) = state.server_shutdown.lock().take() {
+                let _ = tx.send(());
+            }
+        }
+    }
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod chrome;
 pub(crate) mod claude_usage;
 pub(crate) mod cli;
 pub(crate) mod config;
+#[cfg(feature = "desktop")]
 mod dictation;
 pub(crate) mod diff_triage;
 pub(crate) mod error_classification;
@@ -14,7 +15,9 @@ pub(crate) mod fs;
 mod input_line_buffer;
 pub(crate) mod git;
 pub(crate) mod git_cli;
+#[cfg(feature = "desktop")]
 mod global_hotkey;
+#[cfg(feature = "desktop")]
 mod tab_shortcut;
 pub(crate) mod git_graph;
 pub(crate) mod github;
@@ -29,8 +32,11 @@ pub(crate) mod mcp_proxy;
 pub(crate) mod mcp_upstream_config;
 #[allow(dead_code)] // Used by OAuth discovery (story 1193-7f78), not yet wired
 pub(crate) mod mcp_upstream_credentials;
+#[cfg(feature = "desktop")]
 mod menu;
+#[cfg(feature = "desktop")]
 pub(crate) mod notification_sound;
+#[cfg(feature = "desktop")]
 mod panel_window;
 mod output_parser;
 pub(crate) mod plugin_credentials;
@@ -49,8 +55,10 @@ pub(crate) mod credentials;
 pub(crate) mod registry;
 pub(crate) mod pty;
 pub(crate) mod relay_client;
+#[cfg(feature = "desktop")]
 mod tuic_cli;
 mod shell_integration;
+#[cfg(feature = "desktop")]
 pub(crate) mod sleep_prevention;
 pub(crate) mod push;
 pub(crate) mod state;
@@ -59,6 +67,7 @@ pub(crate) mod tailscale;
 pub(crate) mod tool_search;
 pub(crate) mod text_rank;
 pub(crate) mod content_index;
+#[cfg(feature = "desktop")]
 mod updater;
 pub(crate) mod worktree;
 
@@ -818,8 +827,11 @@ pub fn run() {
 
     let mcp_upstream_registry_arc = Arc::new(mcp_proxy::registry::UpstreamRegistry::new());
 
+    let data_dir = config::config_dir();
+
     let state = Arc::new(AppState {
         sessions: DashMap::new(),
+        data_dir,
         worktrees_dir,
         metrics: SessionMetrics::new(),
         output_buffers: DashMap::new(),
@@ -1061,10 +1073,13 @@ pub fn run() {
         .manage(state)
         .manage(ai_chat_registry::ChatRegistry::new())
         .manage(crate::fs::ContentSearchCancel(std::sync::Mutex::new(None)))
-        .manage(dictation::DictationState::new())
-        .manage(sleep_prevention::SleepBlocker::new())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_clipboard_manager::init());
+
+    #[cfg(feature = "desktop")]
+    let builder = builder
+        .manage(dictation::DictationState::new())
+        .manage(sleep_prevention::SleepBlocker::new());
 
     // Single-instance lock only in release builds — allows tauri dev to run
     // alongside the installed TUIC-preview.app (they share the same identifier).
@@ -1082,11 +1097,14 @@ pub fn run() {
             #[cfg(desktop)]
             app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
 
-            let m = menu::build_menu(app)?;
-            app.set_menu(m)?;
-            app.on_menu_event(|app_handle, event| {
-                let _ = app_handle.emit("menu-action", event.id().0.as_str());
-            });
+            #[cfg(feature = "desktop")]
+            {
+                let m = menu::build_menu(app)?;
+                app.set_menu(m)?;
+                app.on_menu_event(|app_handle, event| {
+                    let _ = app_handle.emit("menu-action", event.id().0.as_str());
+                });
+            }
 
             // Store AppHandle so HTTP handlers can emit Tauri events
             let app_state: &Arc<AppState> = app.state::<Arc<AppState>>().inner();
@@ -1105,18 +1123,21 @@ pub fn run() {
                 });
             }
 
-            // Install global hotkey plugin (registers handler, no shortcuts yet)
-            if let Err(e) = global_hotkey::init(app.handle()) {
-                tracing::warn!(source = "global-hotkey", "Failed to init plugin: {e}");
-            } else {
-                global_hotkey::restore_from_config(app.handle());
+            #[cfg(feature = "desktop")]
+            {
+                // Install global hotkey plugin (registers handler, no shortcuts yet)
+                if let Err(e) = global_hotkey::init(app.handle()) {
+                    tracing::warn!(source = "global-hotkey", "Failed to init plugin: {e}");
+                } else {
+                    global_hotkey::restore_from_config(app.handle());
+                }
+
+                // Install Fn/Globe key monitor for push-to-talk dictation
+                dictation::fn_key_monitor::install(app.handle().clone());
+
+                // Install Ctrl+Tab monitor (macOS swallows it before JS/WKWebView)
+                tab_shortcut::install(app.handle().clone());
             }
-
-            // Install Fn/Globe key monitor for push-to-talk dictation
-            dictation::fn_key_monitor::install(app.handle().clone());
-
-            // Install Ctrl+Tab monitor (macOS swallows it before JS/WKWebView)
-            tab_shortcut::install(app.handle().clone());
 
             // Start plugin directory watcher for hot-reload
             plugins::start_plugin_watcher(app.handle());
@@ -1137,6 +1158,7 @@ pub fn run() {
             }
 
             // Auto-update CLI binary if installed
+            #[cfg(feature = "desktop")]
             tuic_cli::auto_update_cli(app.handle());
 
             // Pre-warm content indices for known repos: one at a time, after a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "desktop"), allow(dead_code, unused_imports, unused_variables))]
+
 pub(crate) mod agent;
 pub(crate) mod agent_mcp;
 pub(crate) mod agent_session;
@@ -71,7 +73,6 @@ pub(crate) mod content_index;
 mod updater;
 pub(crate) mod worktree;
 
-use dashmap::DashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(feature = "desktop")]
@@ -79,7 +80,9 @@ use tauri::{Emitter, Manager, State, WebviewWindow};
 
 // Re-export shared types from state module
 pub(crate) use state::{AppState, OutputRingBuffer, PtySession};
-pub(crate) use state::{SessionMetrics, MAX_CONCURRENT_SESSIONS};
+pub(crate) use state::MAX_CONCURRENT_SESSIONS;
+#[cfg(test)]
+pub(crate) use state::SessionMetrics;
 
 #[cfg(feature = "desktop")]
 /// Open a secondary window for multi-monitor use. The window loads the same
@@ -1089,7 +1092,6 @@ pub fn run() {
             let repos_json = config::load_repositories();
             let mut known_repo_paths: Vec<String> = Vec::new();
             if let Some(repos) = repos_json.get("repos").and_then(|r| r.as_object()) {
-                let handle = app.handle().clone();
                 for repo_path in repos.keys() {
                     known_repo_paths.push(repo_path.clone());
                     if let Err(e) = repo_watcher::start_watching(repo_path, app_state) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -850,9 +850,11 @@ pub fn run() {
         server_shutdown: parking_lot::Mutex::new(None),
         ipc_started: std::sync::atomic::AtomicBool::new(false),
         session_token: parking_lot::RwLock::new(config.session_token.clone()),
+        #[cfg(feature = "desktop")]
         app_handle: parking_lot::RwLock::new(None),
         plugin_watchers: DashMap::new(),
         vt_log_buffers: DashMap::new(),
+        #[cfg(feature = "desktop")]
         grid_channels: DashMap::new(),
         grid_watch: DashMap::new(),
         grid_frame_in_flight: DashMap::new(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,12 +74,14 @@ pub(crate) mod worktree;
 use dashmap::DashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{Emitter, Manager, State, WebviewWindow};
 
 // Re-export shared types from state module
 pub(crate) use state::{AppState, OutputRingBuffer, PtySession};
 pub(crate) use state::{SessionMetrics, MAX_CONCURRENT_SESSIONS};
 
+#[cfg(feature = "desktop")]
 /// Open a secondary window for multi-monitor use. The window loads the same
 /// frontend with a `?mode=secondary` query param so App.tsx can render a
 /// pane-only layout without sidebar or tab bar.
@@ -102,6 +104,7 @@ async fn open_secondary_window(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 /// Fix corrupted dimensions in the window-state JSON before the plugin reads it.
 /// titleBarStyle Overlay can persist width/height 0; SIZE is excluded from the
 /// plugin flags so these zeros stay fossilised forever. We patch them at startup.
@@ -131,10 +134,12 @@ fn sanitize_window_state() {
     }
 }
 
+#[cfg(feature = "desktop")]
 /// Ensure the window has valid dimensions and is positioned on a visible monitor.
 /// The window-state plugin can persist invalid state (e.g. width/height 0, or
 /// positions off-screen) which causes downstream failures like PTY garbage output.
 fn ensure_window_visible(window: &WebviewWindow) {
+#[cfg(feature = "desktop")]
     use tauri::PhysicalPosition;
 
     const MIN_WIDTH: u32 = 800;
@@ -181,12 +186,14 @@ fn ensure_window_visible(window: &WebviewWindow) {
     }
 }
 
+#[cfg(feature = "desktop")]
 /// Load configuration from cached AppState
 #[tauri::command]
 fn load_config(state: State<'_, Arc<AppState>>) -> config::AppConfig {
     state.config.read().clone()
 }
 
+#[cfg(feature = "desktop")]
 /// Save configuration to disk, update the AppState cache, and live-restart the HTTP server
 /// if MCP / Remote Access settings changed (no app restart required).
 #[tauri::command]
@@ -216,7 +223,7 @@ fn save_config(state: State<'_, Arc<AppState>>, config: config::AppConfig) -> Re
 }
 
 /// Hash a plaintext password with bcrypt for remote access config
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 async fn hash_password(password: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         bcrypt::hash(&password, 12).map_err(|e| format!("Failed to hash password: {e}"))
@@ -226,12 +233,14 @@ async fn hash_password(password: String) -> Result<String, String> {
 }
 
 /// Clear all git/GitHub operation caches
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn clear_caches(state: State<'_, Arc<AppState>>) {
     state.clear_caches();
 }
 
 /// Clear git/GitHub caches for a specific repo path
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn clear_repo_caches(state: State<'_, Arc<AppState>>, path: String) {
     state.invalidate_repo_caches(&path);
@@ -261,6 +270,7 @@ pub(crate) fn get_local_ips_impl(state: &AppState) -> Vec<LocalIpEntry> {
     get_local_ips_with_config(ipv6_enabled)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn get_local_ips(state: State<'_, Arc<AppState>>) -> Vec<LocalIpEntry> {
     get_local_ips_impl(&state)
@@ -420,6 +430,7 @@ pub(crate) fn pick_preferred_ip(ips: Vec<LocalIpEntry>) -> Option<String> {
 
 /// Legacy single-IP command kept for backwards compatibility.
 /// Returns the LAN/Tailscale IP preferred for remote access, or the default-route IP.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn get_local_ip(state: State<'_, Arc<AppState>>) -> Option<String> {
     pick_preferred_ip(get_local_ips(state))
@@ -505,7 +516,7 @@ pub(crate) fn list_markdown_files_impl(path: String) -> Result<Vec<MarkdownFileE
     Ok(entries)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 fn list_markdown_files(path: String) -> Result<Vec<MarkdownFileEntry>, String> {
     list_markdown_files_impl(path)
 }
@@ -530,7 +541,7 @@ pub(crate) fn read_file_impl(path: String, file: String) -> Result<String, Strin
         .map_err(|e| format!("Failed to read file: {e}"))
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 fn read_file(path: String, file: String) -> Result<String, String> {
     read_file_impl(path, file)
 }
@@ -541,7 +552,7 @@ fn read_file(path: String, file: String) -> Result<String, String> {
 /// No TCC directory blocking: reading a specific file by known path does not
 /// trigger macOS permission dialogs (TCC guards directory enumeration, not
 /// individual reads). The HTTP endpoint has its own repo-root check.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 fn read_external_file(path: String) -> Result<String, String> {
     let p = std::path::Path::new(&path);
     if !p.is_absolute() {
@@ -556,7 +567,7 @@ fn read_external_file(path: String) -> Result<String, String> {
 ///
 /// Target must be inside the user's home directory — see
 /// [`crate::fs::validate_external_write_path`] for the full rationale (story 1273-c95e).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 fn write_external_file(path: String, content: String) -> Result<(), String> {
     let p = std::path::Path::new(&path);
     let home = dirs::home_dir()
@@ -568,6 +579,7 @@ fn write_external_file(path: String, content: String) -> Result<(), String> {
 
 /// Get MCP server status (running, port, active sessions).
 /// Async to avoid blocking the Tauri IPC thread during the TCP self-test.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 async fn get_mcp_status(state: State<'_, Arc<AppState>>) -> Result<serde_json::Value, String> {
     // Collect config and session count synchronously first (fast, no I/O)
@@ -627,6 +639,7 @@ async fn get_mcp_status(state: State<'_, Arc<AppState>>) -> Result<serde_json::V
 
 /// Execute an MCP tool call via deep link: `tuic://cmd/{tool}/{action}?{params}`.
 /// Reuses the same dispatch as the MCP `tools/call` handler — no HTTP round-trip.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 async fn deep_link_mcp_call(
     state: State<'_, Arc<AppState>>,
@@ -655,6 +668,7 @@ async fn deep_link_mcp_call(
 }
 
 /// Regenerate the session token, invalidating all existing remote sessions.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn regenerate_session_token(state: State<'_, Arc<AppState>>) {
     let new_token = uuid::Uuid::new_v4().to_string();
@@ -670,6 +684,7 @@ fn regenerate_session_token(state: State<'_, Arc<AppState>>) {
 /// Build a QR-code connect URL server-side so the raw session token
 /// never reaches JS (where a malicious plugin could steal it).
 /// Uses HTTPS + Tailscale FQDN when TLS is active on a Tailscale IP.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn get_connect_url(state: State<'_, Arc<AppState>>, ip: String) -> String {
     let port = state.config.read().remote_access_port;
@@ -687,11 +702,13 @@ fn get_connect_url(state: State<'_, Arc<AppState>>, ip: String) -> String {
 }
 
 /// Get Tailscale daemon status for the frontend Settings panel.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn get_tailscale_status(state: State<'_, Arc<AppState>>) -> tailscale::TailscaleState {
     state.tailscale_state.read().clone()
 }
 
+#[cfg(feature = "desktop")]
 /// Provision TLS config from current Tailscale state.
 /// Returns Some(RustlsConfig) if Tailscale is running with HTTPS enabled and cert provisioning succeeds.
 async fn provision_tls_config(ts_state: &tailscale::TailscaleState) -> Option<axum_server::tls_rustls::RustlsConfig> {
@@ -712,6 +729,7 @@ async fn provision_tls_config(ts_state: &tailscale::TailscaleState) -> Option<ax
     None
 }
 
+#[cfg(feature = "desktop")]
 /// Restart the HTTP/MCP server with fresh TLS config (reuses the shutdown/spawn pattern from save_config).
 fn restart_server(state: &Arc<AppState>) {
     // Shutdown existing server
@@ -732,6 +750,7 @@ fn restart_server(state: &Arc<AppState>) {
 }
 
 /// Re-detect Tailscale daemon status and restart server if HTTPS availability changed.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 async fn recheck_tailscale_status(state: State<'_, Arc<AppState>>) -> Result<tailscale::TailscaleState, String> {
     let old_https = matches!(
@@ -760,6 +779,7 @@ async fn recheck_tailscale_status(state: State<'_, Arc<AppState>>) -> Result<tai
 }
 
 /// Get relay client status (enabled, connected, url, session_id).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 fn get_relay_status(state: State<'_, Arc<AppState>>) -> serde_json::Value {
     let cfg = state.config.read();
@@ -772,6 +792,7 @@ fn get_relay_status(state: State<'_, Arc<AppState>>) -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "desktop")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Install the rustls CryptoProvider before anything touches TLS.
@@ -1153,7 +1174,7 @@ pub fn run() {
                 let handle = app.handle().clone();
                 for repo_path in repos.keys() {
                     known_repo_paths.push(repo_path.clone());
-                    if let Err(e) = repo_watcher::start_watching(repo_path, Some(&handle), app_state) {
+                    if let Err(e) = repo_watcher::start_watching(repo_path, app_state) {
                         app_logger::log_via_state(app_state, "warn", "app", &format!("[RepoWatcher] Failed to watch {repo_path}: {e}"));
                     }
                 }

--- a/src-tauri/src/llm_api.rs
+++ b/src-tauri/src/llm_api.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_client(config: &LlmApiConfig, api_key: &str) -> genai::Clien
 
 /// Execute a Smart Prompt via direct LLM API call.
 /// Returns the model's response text.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn execute_api_prompt(
     system_prompt: Option<String>,
     content: String,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,13 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(feature = "desktop")]
 fn main() {
     tuicommander_lib::run()
+}
+
+#[cfg(not(feature = "desktop"))]
+fn main() {
+    eprintln!("The desktop GUI requires the 'desktop' feature. Use tuicommander-remote for headless mode.");
+    std::process::exit(1);
 }

--- a/src-tauri/src/mcp_http/agent_routes.rs
+++ b/src-tauri/src/mcp_http/agent_routes.rs
@@ -1,4 +1,4 @@
-use crate::pty::{spawn_headless_reader_thread, spawn_reader_thread};
+use crate::pty::spawn_reader_thread;
 use crate::{AppState, OutputRingBuffer, PtySession, MAX_CONCURRENT_SESSIONS};
 use crate::state::{OUTPUT_RING_BUFFER_CAPACITY, VtLogBuffer, VT_LOG_BUFFER_CAPACITY};
 #[cfg(feature = "desktop")]
@@ -296,16 +296,12 @@ pub(super) async fn spawn_agent_session(
         agent_type: body.agent_type.clone(),
     });
 
-    let app_handle = state.app_handle.read().clone();
-    if let Some(ref app) = app_handle {
-        spawn_reader_thread(reader, paused, session_id.clone(), app.clone(), state, None);
-    } else {
-        spawn_headless_reader_thread(reader, paused, session_id.clone(), state);
-    }
-
-    // Tauri IPC for desktop backward compat
     #[cfg(feature = "desktop")]
-    if let Some(app) = app_handle {
+    let state_ref = state.clone();
+    spawn_reader_thread(reader, paused, session_id.clone(), state, None);
+
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state_ref.app_handle.read().as_ref() {
         let _ = app.emit("session-created", serde_json::json!({
             "session_id": session_id,
             "cwd": body.cwd,

--- a/src-tauri/src/mcp_http/agent_routes.rs
+++ b/src-tauri/src/mcp_http/agent_routes.rs
@@ -1,6 +1,7 @@
 use crate::pty::{spawn_headless_reader_thread, spawn_reader_thread};
 use crate::{AppState, OutputRingBuffer, PtySession, MAX_CONCURRENT_SESSIONS};
 use crate::state::{OUTPUT_RING_BUFFER_CAPACITY, VtLogBuffer, VT_LOG_BUFFER_CAPACITY};
+#[cfg(feature = "desktop")]
 use tauri::Emitter;
 use axum::extract::{ConnectInfo, Query, State};
 use axum::http::StatusCode;
@@ -303,6 +304,7 @@ pub(super) async fn spawn_agent_session(
     }
 
     // Tauri IPC for desktop backward compat
+    #[cfg(feature = "desktop")]
     if let Some(app) = app_handle {
         let _ = app.emit("session-created", serde_json::json!({
             "session_id": session_id,

--- a/src-tauri/src/mcp_http/ai_terminal.rs
+++ b/src-tauri/src/mcp_http/ai_terminal.rs
@@ -253,6 +253,7 @@ pub(crate) async fn handle(
     }
 }
 
+#[cfg(feature = "desktop")]
 async fn confirm_external_write(
     state: &Arc<AppState>,
     tool_name: &str,
@@ -292,6 +293,16 @@ async fn confirm_external_write(
         tracing::warn!(tool_name, error = %e, "confirm_external_write JoinError, denying");
         false
     })
+}
+
+#[cfg(not(feature = "desktop"))]
+async fn confirm_external_write(
+    _state: &Arc<AppState>,
+    tool_name: &str,
+    _args: &serde_json::Value,
+) -> bool {
+    tracing::warn!(tool_name, "confirm_external_write: no desktop feature, denying");
+    false
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp_http/auth.rs
+++ b/src-tauri/src/mcp_http/auth.rs
@@ -177,7 +177,10 @@ pub async fn basic_auth_middleware(
     req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    // Localhost bypass: local Tauri app connections don't need auth
+    // Localhost bypass: only in desktop mode where the Tauri webview connects
+    // locally. Headless mode binds 0.0.0.0 so loopback must be authenticated
+    // like any other address — otherwise any local process gets full access.
+    #[cfg(feature = "desktop")]
     if addr.ip().is_loopback() {
         return next.run(req).await;
     }

--- a/src-tauri/src/mcp_http/dictation_routes.rs
+++ b/src-tauri/src/mcp_http/dictation_routes.rs
@@ -6,6 +6,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use std::collections::HashMap;
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::Manager;
 
 pub(super) async fn get_dictation_status_http(

--- a/src-tauri/src/mcp_http/mcp_transport.rs
+++ b/src-tauri/src/mcp_http/mcp_transport.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{Emitter, Manager};
 use uuid::Uuid;
 
@@ -97,18 +98,20 @@ pub(crate) fn emit_close_html_tabs(state: &AppState, session_id: &str) {
     let Some((_, tab_ids)) = state.session_html_tabs.remove(session_id) else {
         return;
     };
-    let Some(app) = state.app_handle.read().as_ref().cloned() else {
-        // No app handle (test mode or pre-init). Tabs were already drained.
-        return;
-    };
-    if let Err(err) = app.emit("close-html-tabs", serde_json::json!({ "tab_ids": tab_ids })) {
-        tracing::warn!(
-            source = "session",
-            session_id = %session_id,
-            tab_count = tab_ids.len(),
-            error = %err,
-            "failed to emit close-html-tabs — frontend tabs may be orphaned"
-        );
+    let _ = state.event_bus.send(crate::state::AppEvent::CloseHtmlTabs {
+        tab_ids: tab_ids.clone(),
+    });
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state.app_handle.read().as_ref() {
+        if let Err(err) = app.emit("close-html-tabs", serde_json::json!({ "tab_ids": tab_ids })) {
+            tracing::warn!(
+                source = "session",
+                session_id = %session_id,
+                tab_count = tab_ids.len(),
+                error = %err,
+                "failed to emit close-html-tabs — frontend tabs may be orphaned"
+            );
+        }
     }
 }
 
@@ -995,6 +998,7 @@ fn handle_session(state: &Arc<AppState>, args: &serde_json::Value, mcp_session_i
                     session_id: session_id.to_string(),
                     reason: "closed".to_string(),
                 });
+                #[cfg(feature = "desktop")]
                 if let Some(app) = state.app_handle.read().as_ref() {
                     let _ = app.emit("session-closed", serde_json::json!({
                         "session_id": session_id,
@@ -1024,6 +1028,7 @@ fn handle_session(state: &Arc<AppState>, args: &serde_json::Value, mcp_session_i
                     session_id: session_id.to_string(),
                     reason: "killed".to_string(),
                 });
+                #[cfg(feature = "desktop")]
                 if let Some(app) = state.app_handle.read().as_ref() {
                     let _ = app.emit("session-closed", serde_json::json!({
                         "session_id": session_id,
@@ -1274,6 +1279,7 @@ fn handle_worktree(state: &Arc<AppState>, args: &serde_json::Value, is_claude_co
                         branch: branch_name.clone(),
                         worktree_path: wt_path.clone(),
                     });
+                    #[cfg(feature = "desktop")]
                     if let Some(handle) = state.app_handle.read().as_ref() {
                         let _ = handle.emit("worktree-created", serde_json::json!({
                             "repo_path": path,
@@ -1520,12 +1526,15 @@ fn handle_agent(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Valu
             let app_handle = state.app_handle.read().clone();
             if !print_mode {
                 if let Some(ref app) = app_handle {
-                    let agent_type_val = args["agent_type"].as_str();
-                    let _ = app.emit("session-created", serde_json::json!({
-                        "session_id": session_id,
-                        "cwd": cwd_str,
-                        "agent_type": agent_type_val,
-                    }));
+                    #[cfg(feature = "desktop")]
+                    {
+                        let agent_type_val = args["agent_type"].as_str();
+                        let _ = app.emit("session-created", serde_json::json!({
+                            "session_id": session_id,
+                            "cwd": cwd_str,
+                            "agent_type": agent_type_val,
+                        }));
+                    }
                     spawn_reader_thread(reader, paused, session_id.clone(), app.clone(), state.clone(), None);
                 } else {
                     spawn_headless_reader_thread(reader, paused, session_id.clone(), state.clone());
@@ -2238,6 +2247,7 @@ fn handle_ui(state: &Arc<AppState>, args: &serde_json::Value, mcp_session_id: Op
                     .push(id.clone());
             }
             // Emit to Tauri webview (native mode)
+            #[cfg(feature = "desktop")]
             if let Some(app) = state.app_handle.read().as_ref() {
                 let _ = app.emit("ui-tab", &payload);
             }
@@ -2935,6 +2945,7 @@ mod tests {
     fn test_state() -> Arc<AppState> {
         let state = Arc::new(AppState {
             sessions: dashmap::DashMap::new(),
+            data_dir: std::env::temp_dir().join("test-tuic-data"),
             worktrees_dir: std::env::temp_dir().join("test-worktrees"),
             metrics: crate::SessionMetrics::new(),
             output_buffers: dashmap::DashMap::new(),

--- a/src-tauri/src/mcp_http/mcp_transport.rs
+++ b/src-tauri/src/mcp_http/mcp_transport.rs
@@ -2961,9 +2961,11 @@ mod tests {
             server_shutdown: parking_lot::Mutex::new(None),
             ipc_started: std::sync::atomic::AtomicBool::new(false),
             session_token: parking_lot::RwLock::new(uuid::Uuid::new_v4().to_string()),
+            #[cfg(feature = "desktop")]
             app_handle: parking_lot::RwLock::new(None),
             plugin_watchers: dashmap::DashMap::new(),
             vt_log_buffers: dashmap::DashMap::new(),
+            #[cfg(feature = "desktop")]
             grid_channels: dashmap::DashMap::new(),
             grid_watch: dashmap::DashMap::new(),
             grid_frame_in_flight: dashmap::DashMap::new(),

--- a/src-tauri/src/mcp_http/mcp_transport.rs
+++ b/src-tauri/src/mcp_http/mcp_transport.rs
@@ -1522,12 +1522,12 @@ fn handle_agent(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Valu
                 agent_type: agent_type_str,
             });
 
-            let print_mode = args["print_mode"].as_bool().unwrap_or(false);
-            let app_handle = state.app_handle.read().clone();
-            if !print_mode {
-                if let Some(ref app) = app_handle {
-                    #[cfg(feature = "desktop")]
-                    {
+            #[cfg(feature = "desktop")]
+            {
+                let print_mode = args["print_mode"].as_bool().unwrap_or(false);
+                let app_handle = state.app_handle.read().clone();
+                if !print_mode {
+                    if let Some(ref app) = app_handle {
                         let agent_type_val = args["agent_type"].as_str();
                         let _ = app.emit("session-created", serde_json::json!({
                             "session_id": session_id,
@@ -2294,29 +2294,36 @@ fn handle_notify(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Val
             serde_json::json!({"ok": true})
         }
         "confirm" => {
-            if !addr.ip().is_loopback() {
-                return serde_json::json!({"error": "Action 'confirm' is restricted to localhost connections"});
+            #[cfg(not(feature = "desktop"))]
+            {
+                return serde_json::json!({"error": "Action 'confirm' requires desktop feature"});
             }
-            let title = match args["title"].as_str() {
-                Some(t) => t.to_string(),
-                None => return serde_json::json!({"error": "Action 'confirm' requires 'title'"}),
-            };
-            let message = args["message"].as_str().unwrap_or("").to_string();
+            #[cfg(feature = "desktop")]
+            {
+                if !addr.ip().is_loopback() {
+                    return serde_json::json!({"error": "Action 'confirm' is restricted to localhost connections"});
+                }
+                let title = match args["title"].as_str() {
+                    Some(t) => t.to_string(),
+                    None => return serde_json::json!({"error": "Action 'confirm' requires 'title'"}),
+                };
+                let message = args["message"].as_str().unwrap_or("").to_string();
 
-            let app_handle = state.app_handle.read();
-            let handle = match app_handle.as_ref() {
-                Some(h) => h,
-                None => return serde_json::json!({"error": "App handle not available (headless mode)"}),
-            };
+                let app_handle = state.app_handle.read();
+                let handle = match app_handle.as_ref() {
+                    Some(h) => h,
+                    None => return serde_json::json!({"error": "App handle not available (headless mode)"}),
+                };
 
-            use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
-            let confirmed = handle.dialog()
-                .message(&message)
-                .title(&title)
-                .buttons(MessageDialogButtons::OkCancel)
-                .blocking_show();
+                use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+                let confirmed = handle.dialog()
+                    .message(&message)
+                    .title(&title)
+                    .buttons(MessageDialogButtons::OkCancel)
+                    .blocking_show();
 
-            serde_json::json!({"confirmed": confirmed})
+                serde_json::json!({"confirmed": confirmed})
+            }
         }
         other => serde_json::json!({"error": format!(
             "Unknown action '{}' for tool 'notify'. Available: {}", other, LEGACY_NOTIFY_ACTIONS
@@ -2720,22 +2727,28 @@ fn handle_debug_unified(state: &Arc<AppState>, addr: SocketAddr, args: &serde_js
     };
     match action {
         "invoke_js" => {
-            if !addr.ip().is_loopback() {
-                return serde_json::json!({"error": "invoke_js is restricted to localhost connections"});
+            #[cfg(not(feature = "desktop"))]
+            {
+                return serde_json::json!({"error": "invoke_js requires desktop feature"});
             }
-            let script = match args["script"].as_str() {
-                Some(s) => s,
-                None => return serde_json::json!({"error": "script required (string)"}),
-            };
-            let app_handle = state.app_handle.read().clone();
-            let Some(handle) = app_handle else {
-                return serde_json::json!({"error": "AppHandle not initialized"});
-            };
-            let Some(window) = handle.get_webview_window("main") else {
-                return serde_json::json!({"error": "main window not found"});
-            };
-            let wrapped = format!(
-                r#"(async () => {{
+            #[cfg(feature = "desktop")]
+            {
+                if !addr.ip().is_loopback() {
+                    return serde_json::json!({"error": "invoke_js is restricted to localhost connections"});
+                }
+                let script = match args["script"].as_str() {
+                    Some(s) => s,
+                    None => return serde_json::json!({"error": "script required (string)"}),
+                };
+                let app_handle = state.app_handle.read().clone();
+                let Some(handle) = app_handle else {
+                    return serde_json::json!({"error": "AppHandle not initialized"});
+                };
+                let Some(window) = handle.get_webview_window("main") else {
+                    return serde_json::json!({"error": "main window not found"});
+                };
+                let wrapped = format!(
+                    r#"(async () => {{
   const __src = "eval_js";
   const __logs = [];
   const __origLog = console.log;
@@ -2763,13 +2776,14 @@ fn handle_debug_unified(state: &Arc<AppState>, addr: SocketAddr, args: &serde_js
     console.error = __origError;
   }}
 }})()"#
-            );
-            match window.eval(&wrapped) {
-                Ok(()) => serde_json::json!({
-                    "ok": true,
-                    "hint": "Result logged with source='eval_js'. Read via: debug(action='logs', source='eval_js', limit=1)"
-                }),
-                Err(e) => serde_json::json!({"error": format!("eval failed: {e}")}),
+                );
+                match window.eval(&wrapped) {
+                    Ok(()) => serde_json::json!({
+                        "ok": true,
+                        "hint": "Result logged with source='eval_js'. Read via: debug(action='logs', source='eval_js', limit=1)"
+                    }),
+                    Err(e) => serde_json::json!({"error": format!("eval failed: {e}")}),
+                }
             }
         }
         "agent_detection" | "logs" | "sessions" => handle_debug(state, args),

--- a/src-tauri/src/mcp_http/mcp_transport.rs
+++ b/src-tauri/src/mcp_http/mcp_transport.rs
@@ -1,4 +1,4 @@
-use crate::pty::{resolve_shell, spawn_headless_reader_thread, spawn_reader_thread};
+use crate::pty::{resolve_shell, spawn_reader_thread};
 use crate::{AppState, OutputRingBuffer, PtySession, MAX_CONCURRENT_SESSIONS};
 use crate::state::{OUTPUT_RING_BUFFER_CAPACITY, VtLogBuffer, VT_LOG_BUFFER_CAPACITY};
 use axum::extract::{ConnectInfo, State};
@@ -1535,13 +1535,9 @@ fn handle_agent(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Valu
                             "agent_type": agent_type_val,
                         }));
                     }
-                    spawn_reader_thread(reader, paused, session_id.clone(), app.clone(), state.clone(), None);
-                } else {
-                    spawn_headless_reader_thread(reader, paused, session_id.clone(), state.clone());
                 }
-            } else {
-                spawn_headless_reader_thread(reader, paused, session_id.clone(), state.clone());
             }
+            spawn_reader_thread(reader, paused, session_id.clone(), state.clone(), None);
 
             // Auto-register child as peer + pre-init inbox when spawned in swarm context.
             if let Some(ref parent_id) = caller_tuic {

--- a/src-tauri/src/mcp_http/mcp_transport.rs
+++ b/src-tauri/src/mcp_http/mcp_transport.rs
@@ -102,6 +102,7 @@ pub(crate) fn emit_close_html_tabs(state: &AppState, session_id: &str) {
         tab_ids: tab_ids.clone(),
     });
     #[cfg(feature = "desktop")]
+    #[allow(clippy::collapsible_if)]
     if let Some(app) = state.app_handle.read().as_ref() {
         if let Err(err) = app.emit("close-html-tabs", serde_json::json!({ "tab_ids": tab_ids })) {
             tracing::warn!(
@@ -1526,15 +1527,13 @@ fn handle_agent(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Valu
             {
                 let print_mode = args["print_mode"].as_bool().unwrap_or(false);
                 let app_handle = state.app_handle.read().clone();
-                if !print_mode {
-                    if let Some(ref app) = app_handle {
-                        let agent_type_val = args["agent_type"].as_str();
-                        let _ = app.emit("session-created", serde_json::json!({
-                            "session_id": session_id,
-                            "cwd": cwd_str,
-                            "agent_type": agent_type_val,
-                        }));
-                    }
+                if !print_mode && let Some(ref app) = app_handle {
+                    let agent_type_val = args["agent_type"].as_str();
+                    let _ = app.emit("session-created", serde_json::json!({
+                        "session_id": session_id,
+                        "cwd": cwd_str,
+                        "agent_type": agent_type_val,
+                    }));
                 }
             }
             spawn_reader_thread(reader, paused, session_id.clone(), state.clone(), None);
@@ -2296,7 +2295,7 @@ fn handle_notify(state: &Arc<AppState>, addr: SocketAddr, args: &serde_json::Val
         "confirm" => {
             #[cfg(not(feature = "desktop"))]
             {
-                return serde_json::json!({"error": "Action 'confirm' requires desktop feature"});
+                serde_json::json!({"error": "Action 'confirm' requires desktop feature"})
             }
             #[cfg(feature = "desktop")]
             {
@@ -2729,7 +2728,7 @@ fn handle_debug_unified(state: &Arc<AppState>, addr: SocketAddr, args: &serde_js
         "invoke_js" => {
             #[cfg(not(feature = "desktop"))]
             {
-                return serde_json::json!({"error": "invoke_js requires desktop feature"});
+                serde_json::json!({"error": "invoke_js requires desktop feature"})
             }
             #[cfg(feature = "desktop")]
             {

--- a/src-tauri/src/mcp_http/mod.rs
+++ b/src-tauri/src/mcp_http/mod.rs
@@ -954,9 +954,11 @@ mod tests {
             server_shutdown: parking_lot::Mutex::new(None),
             ipc_started: std::sync::atomic::AtomicBool::new(false),
             session_token: parking_lot::RwLock::new(uuid::Uuid::new_v4().to_string()),
+            #[cfg(feature = "desktop")]
             app_handle: parking_lot::RwLock::new(None),
             plugin_watchers: DashMap::new(),
             vt_log_buffers: DashMap::new(),
+            #[cfg(feature = "desktop")]
             grid_channels: DashMap::new(),
             grid_watch: DashMap::new(),
             grid_frame_in_flight: DashMap::new(),

--- a/src-tauri/src/mcp_http/mod.rs
+++ b/src-tauri/src/mcp_http/mod.rs
@@ -934,6 +934,7 @@ mod tests {
     pub(super) fn test_state() -> Arc<AppState> {
         let state = Arc::new(AppState {
             sessions: DashMap::new(),
+            data_dir: std::env::temp_dir().join("test-tuic-data"),
             worktrees_dir: std::env::temp_dir().join("test-worktrees"),
             metrics: crate::SessionMetrics::new(),
             output_buffers: DashMap::new(),

--- a/src-tauri/src/mcp_http/session.rs
+++ b/src-tauri/src/mcp_http/session.rs
@@ -1,6 +1,7 @@
 use crate::pty::{build_shell_command, resolve_shell, spawn_headless_reader_thread, spawn_reader_thread};
 use crate::{AppState, OutputRingBuffer, PtySession, MAX_CONCURRENT_SESSIONS};
 use crate::state::{OUTPUT_RING_BUFFER_CAPACITY, VtLogBuffer, VT_LOG_BUFFER_CAPACITY};
+#[cfg(feature = "desktop")]
 use tauri::Emitter;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, Query, State};
@@ -280,6 +281,7 @@ pub(super) async fn close_session(
             session_id: session_id.clone(),
             reason: "explicit_close".to_string(),
         });
+        #[cfg(feature = "desktop")]
         if let Some(app) = state.app_handle.read().as_ref() {
             let _ = app.emit("session-closed", serde_json::json!({
                 "session_id": session_id,
@@ -389,6 +391,7 @@ pub(super) fn spawn_pty_session(
     }
 
     // Tauri IPC for desktop backward compat
+    #[cfg(feature = "desktop")]
     if let Some(app) = app_handle {
         let _ = app.emit("session-created", serde_json::json!({
             "session_id": session_id,

--- a/src-tauri/src/mcp_http/session.rs
+++ b/src-tauri/src/mcp_http/session.rs
@@ -1,4 +1,4 @@
-use crate::pty::{build_shell_command, resolve_shell, spawn_headless_reader_thread, spawn_reader_thread};
+use crate::pty::{build_shell_command, resolve_shell, spawn_reader_thread};
 use crate::{AppState, OutputRingBuffer, PtySession, MAX_CONCURRENT_SESSIONS};
 use crate::state::{OUTPUT_RING_BUFFER_CAPACITY, VtLogBuffer, VT_LOG_BUFFER_CAPACITY};
 #[cfg(feature = "desktop")]
@@ -381,18 +381,12 @@ pub(super) fn spawn_pty_session(
         agent_type: None,
     });
 
-    // Use full reader thread (with Tauri events) when AppHandle is available,
-    // fall back to headless for tests or pre-setup scenarios
-    let app_handle = state.app_handle.read().clone();
-    if let Some(ref app) = app_handle {
-        spawn_reader_thread(reader, paused, session_id.clone(), app.clone(), state, None);
-    } else {
-        spawn_headless_reader_thread(reader, paused, session_id.clone(), state);
-    }
-
-    // Tauri IPC for desktop backward compat
     #[cfg(feature = "desktop")]
-    if let Some(app) = app_handle {
+    let state_ref = state.clone();
+    spawn_reader_thread(reader, paused, session_id.clone(), state, None);
+
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state_ref.app_handle.read().as_ref() {
         let _ = app.emit("session-created", serde_json::json!({
             "session_id": session_id,
             "cwd": cwd,

--- a/src-tauri/src/mcp_http/sse_routes.rs
+++ b/src-tauri/src/mcp_http/sse_routes.rs
@@ -102,6 +102,7 @@ fn event_type_name(event: &AppEvent) -> &'static str {
         AppEvent::GitHubPrUpdate { .. } => "github-pr-update",
         AppEvent::GitHubTransition { .. } => "github-transition",
         AppEvent::GitHubIssuesUpdate { .. } => "github-issues-update",
+        AppEvent::CloseHtmlTabs { .. } => "close-html-tabs",
     }
 }
 
@@ -165,6 +166,9 @@ fn event_payload(event: &AppEvent) -> serde_json::Value {
         }
         AppEvent::GitHubIssuesUpdate { repo_path, issues } => {
             serde_json::json!({ "repo_path": repo_path, "issues": issues })
+        }
+        AppEvent::CloseHtmlTabs { tab_ids } => {
+            serde_json::json!({ "tab_ids": tab_ids })
         }
     }
 }

--- a/src-tauri/src/mcp_http/watcher_routes.rs
+++ b/src-tauri/src/mcp_http/watcher_routes.rs
@@ -18,8 +18,7 @@ pub(super) async fn start_repo_watcher_http(
     if let Err(e) = validate_repo_path(&q.path) {
         return e.into_response();
     }
-    let app_handle = state.app_handle.read().clone();
-    match crate::repo_watcher::start_watching(&q.path, app_handle.as_ref(), &state) {
+    match crate::repo_watcher::start_watching(&q.path, &state) {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
         Err(e) => err_500(&e),
     }
@@ -45,8 +44,7 @@ pub(super) async fn start_dir_watcher_http(
     if let Err(e) = validate_repo_path(&q.path) {
         return e.into_response();
     }
-    let app_handle = state.app_handle.read().clone();
-    match crate::dir_watcher::start_watching(&q.path, app_handle.as_ref(), &state) {
+    match crate::dir_watcher::start_watching(&q.path, &state) {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
         Err(e) => err_500(&e),
     }

--- a/src-tauri/src/mcp_oauth/commands.rs
+++ b/src-tauri/src/mcp_oauth/commands.rs
@@ -12,6 +12,8 @@
 //! - [`cancel_mcp_upstream_oauth`] — cancels an in-progress flow.
 
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::mcp_oauth::callback_server;
@@ -35,6 +37,7 @@ pub(crate) struct StartOAuthResponse {
 /// browser redirects to `http://127.0.0.1:{port}/oauth/callback` after the
 /// user grants consent. The callback server completes the token exchange and
 /// resumes the upstream connection automatically.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn start_mcp_upstream_oauth(
     state: State<'_, Arc<AppState>>,
@@ -189,6 +192,7 @@ pub(crate) async fn start_mcp_upstream_oauth(
 /// Finalize the OAuth flow after the browser redirects back with `code` and
 /// `state`. On success, upstream tokens are persisted and the upstream is
 /// transitioned back to `Connecting`.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn mcp_oauth_callback(
     state: State<'_, Arc<AppState>>,
@@ -210,6 +214,7 @@ pub(crate) async fn mcp_oauth_callback(
 /// Cancel any in-progress OAuth flows for the named upstream and transition
 /// its status out of `Authenticating`. Safe to call even if no flow is
 /// pending — it becomes a no-op.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn cancel_mcp_upstream_oauth(
     state: State<'_, Arc<AppState>>,

--- a/src-tauri/src/mcp_upstream_config.rs
+++ b/src-tauri/src/mcp_upstream_config.rs
@@ -254,11 +254,12 @@ pub(crate) async fn auto_connect_saved_upstreams(state: &crate::state::AppState)
 // Persistence (Tauri commands)
 // ---------------------------------------------------------------------------
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_mcp_upstreams() -> UpstreamMcpConfig {
     load_json_config(UPSTREAMS_FILE)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn save_mcp_upstreams(
     config: UpstreamMcpConfig,
@@ -311,6 +312,7 @@ fn set_upstream_auth(name: &str, auth: Option<UpstreamAuth>) -> Result<(), Strin
 /// Set per-project upstream MCP allowlist. `None` clears the override
 /// (inherits all globally-enabled servers). Persists to repo-settings.json
 /// and emits a tool-list refresh so connected MCP clients see the change.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn set_project_mcp_upstreams(
     repo_path: String,
@@ -343,6 +345,7 @@ pub(crate) fn set_project_mcp_upstreams_inner(
 /// Reconnect a single upstream by name (disconnect + connect).
 ///
 /// Useful when credentials change or the upstream is temporarily unreachable.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn reconnect_mcp_upstream(
     name: String,
@@ -377,6 +380,7 @@ pub(crate) async fn reconnect_mcp_upstream(
 }
 
 /// Returns a JSON snapshot of all upstream statuses, tool lists, and metrics.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_mcp_upstream_status(
     state: tauri::State<'_, std::sync::Arc<crate::state::AppState>>,

--- a/src-tauri/src/mcp_upstream_credentials.rs
+++ b/src-tauri/src/mcp_upstream_credentials.rs
@@ -182,7 +182,7 @@ pub(crate) fn delete_upstream_credential(upstream_name: &str) -> Result<(), Stri
 // Tauri commands
 // ---------------------------------------------------------------------------
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_mcp_upstream_credential(
     name: String,
     token: String,
@@ -191,7 +191,7 @@ pub(crate) fn save_mcp_upstream_credential(
     save_upstream_credential(&name, &token)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn delete_mcp_upstream_credential(name: String) -> Result<(), String> {
     validate_keyring_name(&name)?;
     delete_upstream_credential(&name)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "desktop")]
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
+#[cfg(feature = "desktop")]
 use tauri::{App, Wry};
 
 /// Build the native system menu bar.

--- a/src-tauri/src/panel_window.rs
+++ b/src-tauri/src/panel_window.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "desktop")]
 use tauri::{Emitter, Manager};
 
 fn validate_panel_id(id: &str) -> Result<(), String> {

--- a/src-tauri/src/plugin_credentials.rs
+++ b/src-tauri/src/plugin_credentials.rs
@@ -38,7 +38,7 @@ fn is_valid_service_name(name: &str) -> bool {
 ///
 /// Returns `Ok(Some(json_string))` if found, `Ok(None)` if not found,
 /// `Err` on I/O or permission errors.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_read_credential(
     service_name: String,
     plugin_id: String,

--- a/src-tauri/src/plugin_credentials.rs
+++ b/src-tauri/src/plugin_credentials.rs
@@ -38,7 +38,8 @@ fn is_valid_service_name(name: &str) -> bool {
 ///
 /// Returns `Ok(Some(json_string))` if found, `Ok(None)` if not found,
 /// `Err` on I/O or permission errors.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_read_credential(
     service_name: String,
     plugin_id: String,

--- a/src-tauri/src/plugin_exec.rs
+++ b/src-tauri/src/plugin_exec.rs
@@ -164,7 +164,7 @@ fn validate_cwd(cwd: &str) -> Result<std::path::PathBuf, String> {
 /// - 30-second timeout
 /// - 5 MB stdout limit
 /// - stderr is captured but not returned (logged on failure)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_exec_cli(
     binary: String,
     args: Vec<String>,

--- a/src-tauri/src/plugin_exec.rs
+++ b/src-tauri/src/plugin_exec.rs
@@ -164,7 +164,8 @@ fn validate_cwd(cwd: &str) -> Result<std::path::PathBuf, String> {
 /// - 30-second timeout
 /// - 5 MB stdout limit
 /// - stderr is captured but not returned (logged on failure)
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_exec_cli(
     binary: String,
     args: Vec<String>,

--- a/src-tauri/src/plugin_fs.rs
+++ b/src-tauri/src/plugin_fs.rs
@@ -83,7 +83,7 @@ fn validate_within_home(raw: &str) -> Result<PathBuf, String> {
 
 /// Read a file's content as UTF-8 text.
 /// Validates the path is within $HOME, enforces a 10 MB size limit.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_read_file(
     path: String,
     plugin_id: String,
@@ -114,7 +114,7 @@ pub async fn plugin_read_file(
 
 /// List filenames in a directory, optionally filtered by a glob pattern.
 /// Returns filenames only (not full paths). Validates path is within $HOME.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_list_directory(
     path: String,
     pattern: Option<String>,
@@ -179,7 +179,7 @@ async fn plugin_list_directory_inner(
 /// Seeks to `file_size - max_bytes`, then skips to the next newline to avoid
 /// partial lines. If the file is smaller than `max_bytes`, reads the entire file.
 /// Validates path is within $HOME, same as plugin_read_file.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_read_file_tail(
     path: String,
     max_bytes: u64,
@@ -236,7 +236,7 @@ async fn plugin_read_file_tail_inner(
 /// Start watching a path for filesystem changes.
 /// Returns a watch_id (UUID) that can be used with plugin_unwatch.
 /// Emits `plugin-fs-change-{plugin_id}` Tauri events on changes.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_watch_path(
     path: String,
     plugin_id: String,
@@ -283,7 +283,7 @@ pub async fn plugin_watch_path(
 }
 
 /// Stop watching a previously registered path.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_unwatch(
     watch_id: String,
     _plugin_id: String,
@@ -378,7 +378,7 @@ const MAX_WRITE_SIZE: usize = 10 * 1024 * 1024;
 
 /// Write content to a file within $HOME.
 /// Creates parent directories if needed. Refuses to overwrite directories.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_write_file(
     path: String,
     content: String,
@@ -439,7 +439,7 @@ async fn plugin_write_file_inner(
 
 /// Rename/move a file within $HOME.
 /// Both source and destination must be within $HOME. Source must exist.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_rename_path(
     from: String,
     to: String,

--- a/src-tauri/src/plugin_fs.rs
+++ b/src-tauri/src/plugin_fs.rs
@@ -8,6 +8,7 @@ use crate::AppState;
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, State};
 
 /// Maximum file size readable via plugin_read_file (10 MB).
@@ -83,7 +84,8 @@ fn validate_within_home(raw: &str) -> Result<PathBuf, String> {
 
 /// Read a file's content as UTF-8 text.
 /// Validates the path is within $HOME, enforces a 10 MB size limit.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_read_file(
     path: String,
     plugin_id: String,
@@ -114,7 +116,8 @@ pub async fn plugin_read_file(
 
 /// List filenames in a directory, optionally filtered by a glob pattern.
 /// Returns filenames only (not full paths). Validates path is within $HOME.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_list_directory(
     path: String,
     pattern: Option<String>,
@@ -179,7 +182,8 @@ async fn plugin_list_directory_inner(
 /// Seeks to `file_size - max_bytes`, then skips to the next newline to avoid
 /// partial lines. If the file is smaller than `max_bytes`, reads the entire file.
 /// Validates path is within $HOME, same as plugin_read_file.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_read_file_tail(
     path: String,
     max_bytes: u64,
@@ -236,7 +240,8 @@ async fn plugin_read_file_tail_inner(
 /// Start watching a path for filesystem changes.
 /// Returns a watch_id (UUID) that can be used with plugin_unwatch.
 /// Emits `plugin-fs-change-{plugin_id}` Tauri events on changes.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_watch_path(
     path: String,
     plugin_id: String,
@@ -283,7 +288,8 @@ pub async fn plugin_watch_path(
 }
 
 /// Stop watching a previously registered path.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_unwatch(
     watch_id: String,
     _plugin_id: String,
@@ -300,6 +306,7 @@ pub async fn plugin_unwatch(
 // Debounce loop
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "desktop")]
 /// Collect notify events and emit batched Tauri events after a quiet period.
 fn debounce_loop(
     rx: std::sync::mpsc::Receiver<notify::Result<Event>>,
@@ -378,7 +385,8 @@ const MAX_WRITE_SIZE: usize = 10 * 1024 * 1024;
 
 /// Write content to a file within $HOME.
 /// Creates parent directories if needed. Refuses to overwrite directories.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_write_file(
     path: String,
     content: String,
@@ -439,7 +447,8 @@ async fn plugin_write_file_inner(
 
 /// Rename/move a file within $HOME.
 /// Both source and destination must be within $HOME. Source must exist.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_rename_path(
     from: String,
     to: String,

--- a/src-tauri/src/plugin_http.rs
+++ b/src-tauri/src/plugin_http.rs
@@ -117,7 +117,7 @@ fn url_matches_pattern(url: &str, pattern: &str) -> bool {
 /// - `body` — Optional request body
 /// - `allowed_urls` — URL patterns from the plugin's manifest (empty = unrestricted)
 /// - `plugin_id` — The requesting plugin's ID (for logging)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_http_fetch(
     url: String,
     method: Option<String>,
@@ -192,7 +192,7 @@ pub async fn plugin_http_fetch(
 
 /// Fetch HTML content from a URL for rendering in a plugin panel tab.
 /// Internal frontend command — no SSRF restrictions (localhost, private IPs all valid).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn fetch_tab_html(url: String) -> Result<String, String> {
 
     let response = shared_client()

--- a/src-tauri/src/plugin_http.rs
+++ b/src-tauri/src/plugin_http.rs
@@ -117,7 +117,8 @@ fn url_matches_pattern(url: &str, pattern: &str) -> bool {
 /// - `body` — Optional request body
 /// - `allowed_urls` — URL patterns from the plugin's manifest (empty = unrestricted)
 /// - `plugin_id` — The requesting plugin's ID (for logging)
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_http_fetch(
     url: String,
     method: Option<String>,

--- a/src-tauri/src/plugin_pty.rs
+++ b/src-tauri/src/plugin_pty.rs
@@ -23,7 +23,7 @@ const DEFAULT_LINES: usize = 200;
 ///
 /// Requires the `pty:read` capability. Returns an error if the session does
 /// not exist (closed or never created).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn plugin_read_session_output(
     session_id: String,
     max_lines: Option<usize>,

--- a/src-tauri/src/plugin_pty.rs
+++ b/src-tauri/src/plugin_pty.rs
@@ -23,7 +23,8 @@ const DEFAULT_LINES: usize = 200;
 ///
 /// Requires the `pty:read` capability. Returns an error if the session does
 /// not exist (closed or never created).
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn plugin_read_session_output(
     session_id: String,
     max_lines: Option<usize>,

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -329,7 +329,7 @@ pub fn register_plugin_protocol(builder: tauri::Builder<tauri::Wry>) -> tauri::B
 
 /// Scan the user plugins directory and return all valid manifests.
 /// Invalid manifests are logged and skipped — never cause an error.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn list_user_plugins() -> Vec<PluginManifest> {
     let dir = plugins_dir();
     if !dir.exists() {
@@ -407,7 +407,7 @@ pub fn list_user_plugins() -> Vec<PluginManifest> {
 ///
 /// Security: validates the claimed capabilities against the on-disk manifest.
 /// The frontend cannot self-register arbitrary capabilities.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn register_loaded_plugin(
     plugin_id: String,
     capabilities: Vec<String>,
@@ -445,7 +445,7 @@ pub(crate) fn read_single_manifest(plugin_id: &str) -> Result<PluginManifest, St
 }
 
 /// Unregister a plugin's capabilities when it is unloaded.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn unregister_loaded_plugin(
     plugin_id: String,
     state: tauri::State<'_, std::sync::Arc<crate::AppState>>,
@@ -459,7 +459,7 @@ pub fn unregister_loaded_plugin(
 
 /// Return the absolute path to a plugin's README.md if it exists.
 /// Returns `None` if the file doesn't exist (not an error).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn get_plugin_readme_path(id: String) -> Option<String> {
     if id.is_empty() || is_path_escape(&id) {
         return None;
@@ -496,7 +496,7 @@ fn resolve_data_path(plugin_id: &str, relative_path: &str) -> Result<PathBuf, St
     Ok(data_dir.join(relative_path))
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn read_plugin_data(plugin_id: String, path: String) -> Result<Option<String>, String> {
     let file_path = resolve_data_path(&plugin_id, &path)?;
     match std::fs::read_to_string(&file_path) {
@@ -506,7 +506,7 @@ pub fn read_plugin_data(plugin_id: String, path: String) -> Result<Option<String
     }
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn write_plugin_data(plugin_id: String, path: String, content: String) -> Result<(), String> {
     let file_path = resolve_data_path(&plugin_id, &path)?;
     if let Some(parent) = file_path.parent() {
@@ -517,7 +517,7 @@ pub fn write_plugin_data(plugin_id: String, path: String, content: String) -> Re
         .map_err(|e| format!("Failed to write plugin data: {e}"))
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn delete_plugin_data(plugin_id: String, path: String) -> Result<(), String> {
     let file_path = resolve_data_path(&plugin_id, &path)?;
     match std::fs::remove_file(&file_path) {
@@ -538,7 +538,7 @@ pub fn delete_plugin_data(plugin_id: String, path: String) -> Result<(), String>
 /// the `data/` subdirectory is preserved across the overwrite.
 ///
 /// Returns the validated manifest on success.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn install_plugin_from_zip(
     path: String,
     app_handle: AppHandle,
@@ -552,7 +552,7 @@ pub async fn install_plugin_from_zip(
 }
 
 /// Install a plugin from an HTTPS URL: download to a temp file, then extract.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn install_plugin_from_url(
     url: String,
     app_handle: AppHandle,
@@ -669,7 +669,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
 
 /// Install a plugin from a local folder. Validates manifest, copies files to
 /// the plugins directory, preserves existing data/, and emits a reload event.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn install_plugin_from_folder(
     path: String,
     app_handle: AppHandle,
@@ -821,7 +821,7 @@ fn find_manifest_in_zip(archive: &zip::ZipArchive<std::fs::File>) -> Result<Stri
 // ---------------------------------------------------------------------------
 
 /// Remove a plugin and all its files (including data/).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn uninstall_plugin(id: String, app_handle: AppHandle) -> Result<(), String> {
     if id.is_empty() || is_path_escape(&id) {
         return Err("Invalid plugin ID".into());

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -12,7 +12,9 @@
 use crate::config;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
+#[cfg(feature = "desktop")]
 use tauri::http::{Response, StatusCode};
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter};
 
 // ---------------------------------------------------------------------------
@@ -267,6 +269,7 @@ fn resolve_plugin_path(uri_path: &str) -> Option<PathBuf> {
 // URI protocol handler
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "desktop")]
 /// Register the `plugin://` custom URI scheme protocol on the Tauri builder.
 ///
 /// Serves JS files from `{config_dir}/plugins/{id}/{file}` with the
@@ -407,7 +410,8 @@ pub fn list_user_plugins() -> Vec<PluginManifest> {
 ///
 /// Security: validates the claimed capabilities against the on-disk manifest.
 /// The frontend cannot self-register arbitrary capabilities.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub fn register_loaded_plugin(
     plugin_id: String,
     capabilities: Vec<String>,
@@ -445,7 +449,8 @@ pub(crate) fn read_single_manifest(plugin_id: &str) -> Result<PluginManifest, St
 }
 
 /// Unregister a plugin's capabilities when it is unloaded.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub fn unregister_loaded_plugin(
     plugin_id: String,
     state: tauri::State<'_, std::sync::Arc<crate::AppState>>,
@@ -538,7 +543,8 @@ pub fn delete_plugin_data(plugin_id: String, path: String) -> Result<(), String>
 /// the `data/` subdirectory is preserved across the overwrite.
 ///
 /// Returns the validated manifest on success.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn install_plugin_from_zip(
     path: String,
     app_handle: AppHandle,
@@ -552,7 +558,8 @@ pub async fn install_plugin_from_zip(
 }
 
 /// Install a plugin from an HTTPS URL: download to a temp file, then extract.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn install_plugin_from_url(
     url: String,
     app_handle: AppHandle,
@@ -621,6 +628,7 @@ fn prepare_plugin_target(manifest: &PluginManifest) -> Result<PreparedTarget, St
     Ok(PreparedTarget { path: target_dir, data_backup })
 }
 
+#[cfg(feature = "desktop")]
 /// Restore data/ backup, emit plugin-changed event, log success.
 fn finalize_plugin_install(
     target: PreparedTarget,
@@ -669,7 +677,8 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
 
 /// Install a plugin from a local folder. Validates manifest, copies files to
 /// the plugins directory, preserves existing data/, and emits a reload event.
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub async fn install_plugin_from_folder(
     path: String,
     app_handle: AppHandle,
@@ -700,6 +709,7 @@ pub async fn install_plugin_from_folder(
     finalize_plugin_install(target, &manifest, &app_handle)
 }
 
+#[cfg(feature = "desktop")]
 /// Core ZIP extraction logic shared by install_plugin_from_zip and install_plugin_from_url.
 fn install_zip_inner(
     zip_path: &std::path::Path,
@@ -821,7 +831,8 @@ fn find_manifest_in_zip(archive: &zip::ZipArchive<std::fs::File>) -> Result<Stri
 // ---------------------------------------------------------------------------
 
 /// Remove a plugin and all its files (including data/).
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub fn uninstall_plugin(id: String, app_handle: AppHandle) -> Result<(), String> {
     if id.is_empty() || is_path_escape(&id) {
         return Err("Invalid plugin ID".into());
@@ -844,6 +855,7 @@ pub fn uninstall_plugin(id: String, app_handle: AppHandle) -> Result<(), String>
 // Plugin directory watcher (hot reload)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "desktop")]
 /// Start watching the plugins directory for changes and emit `plugin-changed`
 /// events to the frontend. Uses the same debouncer pattern as repo_watcher.
 pub fn start_plugin_watcher(app_handle: &AppHandle) {

--- a/src-tauri/src/prompt.rs
+++ b/src-tauri/src/prompt.rs
@@ -154,12 +154,12 @@ fn cmd_shell_quote(value: &str) -> String {
     out
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn extract_prompt_variables(content: String) -> Vec<String> {
     extract_variables(&content)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn process_prompt_content(
     content: String,
     variables: HashMap<String, String>,
@@ -172,7 +172,7 @@ pub(crate) fn process_prompt_content(
 /// `process_prompt_content` whenever the resulting string is going to be
 /// handed to `sh -c` / `cmd /C`, otherwise repo-controlled variables like
 /// `{branch}` or `{pr_title}` can execute arbitrary commands.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn process_prompt_content_shell_safe(
     content: String,
     variables: HashMap<String, String>,
@@ -415,7 +415,7 @@ pub(crate) struct PromptVarsResult {
 /// that actually appear, and returns both the resolved map and the full list
 /// of variable names (so the frontend can detect unresolved ones without a
 /// second IPC round-trip).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn resolve_prompt_variables(
     content: String,
     repo_path: Option<String>,
@@ -433,7 +433,7 @@ pub(crate) async fn resolve_prompt_variables(
 }
 
 /// Resolve all git context variables (used by the MCP endpoint).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn resolve_context_variables(repo_path: String) -> Result<HashMap<String, String>, String> {
     tokio::task::spawn_blocking(move || {
         let all: Vec<String> = ALL_VARS.iter().map(|s| s.to_string()).collect();

--- a/src-tauri/src/provider_registry.rs
+++ b/src-tauri/src/provider_registry.rs
@@ -402,23 +402,23 @@ pub(crate) fn resolve_slot(
 // Tauri commands
 // ---------------------------------------------------------------------------
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn load_provider_registry() -> ProviderRegistry {
     load_registry()
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_provider_registry(registry: ProviderRegistry) -> Result<(), String> {
     save_registry(&registry)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_provider_api_key_exists(provider_id: String) -> Result<bool, String> {
     crate::credentials::get(crate::credentials::Credential::Provider(&provider_id))
         .map(|v| v.is_some())
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn save_provider_api_key(provider_id: String, key: String) -> Result<(), String> {
     if key.is_empty() {
         return Err("API key must not be empty".to_string());
@@ -426,12 +426,12 @@ pub(crate) fn save_provider_api_key(provider_id: String, key: String) -> Result<
     crate::credentials::set(crate::credentials::Credential::Provider(&provider_id), &key)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn delete_provider_api_key(provider_id: String) -> Result<(), String> {
     crate::credentials::delete(crate::credentials::Credential::Provider(&provider_id))
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn test_slot_connection(slot: SlotName) -> Result<String, String> {
     use genai::chat::{ChatMessage, ChatRequest};
 
@@ -459,7 +459,7 @@ pub(crate) async fn test_slot_connection(slot: SlotName) -> Result<String, Strin
     Ok(format!("Connection successful — model replied: {text}"))
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn check_ollama_models(provider_id: String) -> crate::ai_chat::OllamaStatus {
     let registry = load_registry();
     let base = registry

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -2194,6 +2194,7 @@ pub(crate) fn cleanup_session(session_id: &str, state: &AppState) {
     }
     state.output_buffers.remove(session_id);
     state.vt_log_buffers.remove(session_id);
+    #[cfg(feature = "desktop")]
     state.grid_channels.remove(session_id);
     state.grid_watch.remove(session_id);
     state.grid_frame_in_flight.remove(session_id);
@@ -2223,6 +2224,7 @@ fn tombstone_transient_cleanup(session_id: &str, state: &AppState) {
         .or_insert_with(|| AtomicU64::new(0))
         .store(now_ms, Ordering::Relaxed);
     state.ws_clients.remove(session_id);
+    #[cfg(feature = "desktop")]
     state.grid_channels.remove(session_id);
     state.grid_watch.remove(session_id);
     state.grid_frame_in_flight.remove(session_id);
@@ -4069,6 +4071,7 @@ pub(crate) fn send_grid_frame(state: &AppState, session_id: &str, frame: Vec<u8>
     {
         let _ = watch_tx.send(frame.clone());
     }
+    #[cfg(feature = "desktop")]
     if let Some(ch) = state.grid_channels.get(session_id) {
         if let Some(flag) = state.grid_frame_in_flight.get(session_id) {
             flag.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
 use crate::input_line_buffer::{InputAction, InputLineBuffer};
@@ -2916,9 +2916,7 @@ pub(crate) async fn create_pty(
         }
 
         // Inject OSC 133 shell integration (command block markers)
-        if let Ok(data_dir) = app.path().app_data_dir() {
-            crate::shell_integration::inject(&data_dir, &shell, &mut cmd);
-        }
+        crate::shell_integration::inject(&state.data_dir, &shell, &mut cmd);
 
         // Inject stable session UUID so agents can use it for session binding
         // (e.g. `claude --session-id $TUIC_SESSION`, then `claude --resume $TUIC_SESSION`)
@@ -3044,9 +3042,7 @@ pub(crate) async fn spawn_session_for_agent(
         cmd.cwd(expanded);
     }
 
-    if let Ok(data_dir) = app.path().app_data_dir() {
-        crate::shell_integration::inject(&data_dir, &shell, &mut cmd);
-    }
+    crate::shell_integration::inject(&state.data_dir, &shell, &mut cmd);
 
     let child = pair
         .slave
@@ -3157,9 +3153,7 @@ pub(crate) async fn create_pty_with_worktree(
         cmd.cwd(&worktree_path);
 
         // Inject OSC 133 shell integration (command block markers)
-        if let Ok(data_dir) = app.path().app_data_dir() {
-            crate::shell_integration::inject(&data_dir, &shell, &mut cmd);
-        }
+        crate::shell_integration::inject(&state.data_dir, &shell, &mut cmd);
 
         // Inject env flags (feature flags configured in Settings → Agents)
         for (key, value) in &pty_config.env {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
@@ -2867,6 +2868,7 @@ pub(crate) fn spawn_headless_reader_thread(
 }
 
 /// Create a new PTY session with optional worktree
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn create_pty(
     app: AppHandle,
@@ -3112,6 +3114,7 @@ pub(crate) async fn spawn_session_for_agent(
 }
 
 /// Create a PTY session with a dedicated git worktree
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn create_pty_with_worktree(
     app: AppHandle,
@@ -3251,6 +3254,7 @@ pub(crate) async fn create_pty_with_worktree(
 }
 
 /// List all active worktrees
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn list_worktrees(state: State<'_, Arc<AppState>>) -> Vec<serde_json::Value> {
     state.sessions
@@ -3271,6 +3275,7 @@ pub(crate) fn list_worktrees(state: State<'_, Arc<AppState>>) -> Vec<serde_json:
 }
 
 /// Write data to a PTY session
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn write_pty(
     app: AppHandle,
@@ -3391,6 +3396,7 @@ pub(crate) async fn write_pty(
 
 /// Return the current content of the input line buffer for a PTY session.
 /// Empty string when the user has not started typing.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_input_buffer_content(
     state: State<'_, Arc<AppState>>,
@@ -3404,6 +3410,7 @@ pub(crate) fn get_input_buffer_content(
 }
 
 /// Get the last relevant user prompt (>= 10 words) for a PTY session.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_last_prompt(
     state: State<'_, Arc<AppState>>,
@@ -3415,6 +3422,7 @@ pub(crate) fn get_last_prompt(
 /// Get the current shell state for a PTY session.
 /// Used by the frontend on remount to sync state missed while unsubscribed.
 /// Returns "busy", "idle", or null (session never produced output / removed).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_shell_state(
     state: State<'_, Arc<AppState>>,
@@ -3429,6 +3437,7 @@ pub(crate) fn get_shell_state(
 /// Lets the frontend pick the correct control sequences (e.g. Ctrl-U as
 /// line-kill for POSIX readline vs. literal-char on cmd.exe/PowerShell)
 /// without re-deriving the classification on every keystroke.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_session_shell_family(
     state: State<'_, Arc<AppState>>,
@@ -3442,6 +3451,7 @@ pub(crate) fn get_session_shell_family(
 
 /// Enable or disable VT100 diff rendering for a PTY session.
 /// Resize a PTY session
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn resize_pty(
     state: State<'_, Arc<AppState>>,
@@ -3482,6 +3492,7 @@ pub(crate) fn resize_pty(
 }
 
 /// Pause PTY reader thread (flow control: frontend buffer full)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn pause_pty(state: State<'_, Arc<AppState>>, session_id: String) -> Result<(), String> {
     let entry = state.sessions
@@ -3494,6 +3505,7 @@ pub(crate) fn pause_pty(state: State<'_, Arc<AppState>>, session_id: String) -> 
 }
 
 /// Resume PTY reader thread (flow control: frontend buffer drained)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn resume_pty(state: State<'_, Arc<AppState>>, session_id: String) -> Result<(), String> {
     let entry = state.sessions
@@ -3506,6 +3518,7 @@ pub(crate) fn resume_pty(state: State<'_, Arc<AppState>>, session_id: String) ->
 
 /// Query current kitty keyboard protocol flags for a session.
 /// Returns 0 if the session has no kitty state (protocol not activated).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_kitty_flags(
     state: State<'_, Arc<AppState>>,
@@ -3631,6 +3644,7 @@ pub(crate) fn kill_pty_core(state: &AppState, session_id: &str) -> bool {
 /// Close a PTY session with graceful shutdown and optional worktree cleanup.
 /// Sends Ctrl-C (0x03) and waits briefly for the process to exit cleanly
 /// before forcibly dropping handles.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn close_pty(
     state: State<'_, Arc<AppState>>,
@@ -3855,6 +3869,7 @@ pub(crate) fn classify_agent(process_name: &str) -> Option<&'static str> {
 /// recognise (custom aliases, symlinks, wrapper scripts like "C2"), falls back
 /// to the pre-set `session_states.agent_type` so run-config launches are
 /// detected correctly without hardcoding every possible alias.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_session_foreground_process(
     state: State<'_, Arc<AppState>>,
@@ -3923,6 +3938,7 @@ pub(crate) fn get_session_foreground_process(
 /// Check if a PTY session has a non-shell foreground process running.
 /// Returns the process name (e.g. "htop", "node", "claude") or None if
 /// the foreground is the shell itself (zsh, bash, fish, etc.).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn has_foreground_process(
     state: State<'_, Arc<AppState>>,
@@ -3952,6 +3968,7 @@ pub(crate) fn has_foreground_process(
 
 /// Debug: diagnose agent detection for a PTY session.
 /// Returns each step of the detection pipeline so failures can be pinpointed.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn debug_agent_detection(
     state: State<'_, Arc<AppState>>,
@@ -3995,18 +4012,21 @@ pub(crate) fn debug_agent_detection(
 }
 
 /// Get orchestrator stats
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_orchestrator_stats(state: State<'_, Arc<AppState>>) -> OrchestratorStats {
     state.orchestrator_stats()
 }
 
 /// Get PTY session metrics for observability
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_session_metrics(state: State<'_, Arc<AppState>>) -> serde_json::Value {
     state.session_metrics_json()
 }
 
 /// Check if we can spawn a new session
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn can_spawn_session(state: State<'_, Arc<AppState>>) -> bool {
     state.sessions.len() < MAX_CONCURRENT_SESSIONS
@@ -4024,6 +4044,7 @@ pub(crate) struct ActiveSessionInfo {
 /// Update the working directory of a running PTY session.
 /// Called from the frontend when an OSC 7 escape sequence is detected,
 /// keeping the Rust-side cwd in sync for restart recovery.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn update_session_cwd(
     state: State<'_, Arc<AppState>>,
@@ -4046,6 +4067,7 @@ pub(crate) fn update_session_cwd(
 }
 
 /// Set the display name of a PTY session (syncs tab title to backend for PWA visibility).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn set_session_name(
     state: State<'_, Arc<AppState>>,
@@ -4061,6 +4083,7 @@ pub(crate) fn set_session_name(
 }
 
 /// List all active PTY sessions for reconnection after frontend reload
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn list_active_sessions(state: State<'_, Arc<AppState>>) -> Vec<ActiveSessionInfo> {
     state
@@ -4095,6 +4118,7 @@ pub struct VtLogChunk {
 /// This is the desktop IPC equivalent of the PWA WebSocket `format=log` path.
 /// `lines` are finalized scrollback lines (each appears once, oldest first).
 /// `screen` is the current visible screen with agent chrome trimmed.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn read_vt_log(
     state: State<'_, Arc<AppState>>,
@@ -4150,6 +4174,7 @@ pub(crate) fn send_grid_frame(state: &AppState, session_id: &str, frame: Vec<u8>
 /// The frontend calls this once per terminal; subsequent PTY output triggers
 /// `serialize_dirty_rows()` on the session's TerminalGrid and sends the result
 /// via the channel. Replaces any previously registered channel for the session.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn subscribe_terminal_grid(
     state: State<'_, Arc<AppState>>,
@@ -4164,6 +4189,7 @@ pub(crate) fn subscribe_terminal_grid(
 /// Clears the in-flight flag so the PTY reader can send the next frame.
 /// If the VT grid has accumulated dirty rows while in-flight (PTY went idle
 /// before the reader could send another frame), flush them immediately.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn ack_terminal_frame(
     state: State<'_, Arc<AppState>>,
@@ -4188,6 +4214,7 @@ pub(crate) fn ack_terminal_frame(
 }
 
 /// Request a full frame for a session (used after subscribe to get initial state).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_request_frame(
     state: State<'_, Arc<AppState>>,
@@ -4204,6 +4231,7 @@ pub(crate) fn terminal_request_frame(
 }
 
 /// Unregister the grid channel for a session (called by the frontend on unmount).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn unsubscribe_terminal_grid(
     state: State<'_, Arc<AppState>>,
@@ -4216,6 +4244,7 @@ pub(crate) fn unsubscribe_terminal_grid(
 /// Exit alternate screen via the terminal grid (display side only, never touches PTY stdin).
 /// Only injects the exit sequences when the grid is actually in alternate-screen mode,
 /// preventing escape leaks into the shell when the agent already cleaned up normally.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_exit_alt_screen(
     state: State<'_, Arc<AppState>>,
@@ -4241,6 +4270,7 @@ pub(crate) fn terminal_exit_alt_screen(
 
 // --- Scroll commands ---
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_scroll(
     state: State<'_, Arc<AppState>>,
@@ -4257,6 +4287,7 @@ pub(crate) fn terminal_scroll(
     }
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_scroll_to(
     state: State<'_, Arc<AppState>>,
@@ -4273,6 +4304,7 @@ pub(crate) fn terminal_scroll_to(
     }
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_scroll_info(
     state: State<'_, Arc<AppState>>,
@@ -4288,6 +4320,7 @@ pub(crate) fn terminal_scroll_info(
 
 // --- Search command ---
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_search(
     state: State<'_, Arc<AppState>>,
@@ -4299,6 +4332,7 @@ pub(crate) fn terminal_search(
         .unwrap_or_default()
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_search_buffer(
     state: State<'_, Arc<AppState>>,
@@ -4312,6 +4346,7 @@ pub(crate) fn terminal_search_buffer(
 
 // --- Row text command ---
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_get_row_text(
     state: State<'_, Arc<AppState>>,
@@ -4323,6 +4358,7 @@ pub(crate) fn terminal_get_row_text(
         .unwrap_or_default()
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_get_lines(
     state: State<'_, Arc<AppState>>,
@@ -4335,6 +4371,7 @@ pub(crate) fn terminal_get_lines(
         .unwrap_or_default()
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_get_cursor_line(
     state: State<'_, Arc<AppState>>,
@@ -4345,6 +4382,7 @@ pub(crate) fn terminal_get_cursor_line(
         .unwrap_or_default()
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn terminal_hyperlink_at(
     state: State<'_, Arc<AppState>>,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -920,7 +920,6 @@ fn should_transition_idle(state: &crate::state::AppState, session_id: &str) -> I
 /// Emit a ShellState parsed event via both event bus and Tauri IPC.
 fn emit_shell_state(
     state: &crate::state::AppState,
-    app: Option<&tauri::AppHandle>,
     session_id: &str,
     shell_state: &str,
 ) {
@@ -933,7 +932,8 @@ fn emit_shell_state(
             parsed: json,
         });
     }
-    if let Some(app) = app {
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state.app_handle.read().as_ref() {
         let _ = app.emit(
             &format!("pty-parsed-{session_id}"),
             &parsed,
@@ -945,7 +945,6 @@ fn emit_shell_state(
 /// Shared by OSC 133 A/C handlers and OSC 7770 `state=` handler.
 fn transition_shell_state(
     state: &crate::state::AppState,
-    app: Option<&tauri::AppHandle>,
     session_id: &str,
     target: u8,
     label: &str,
@@ -953,7 +952,7 @@ fn transition_shell_state(
     if let Some(atom) = state.shell_states.get(session_id) {
         let prev = atom.load(std::sync::atomic::Ordering::Acquire);
         if prev != target && try_shell_transition(state, session_id, prev, target, true) {
-            emit_shell_state(state, app, session_id, label);
+            emit_shell_state(state, session_id, label);
         }
     }
 }
@@ -963,7 +962,6 @@ fn transition_shell_state(
 /// sync after `should_transition_idle` force-clears the in-memory counter.
 fn emit_active_subtasks(
     state: &crate::state::AppState,
-    app: Option<&tauri::AppHandle>,
     session_id: &str,
     count: u32,
     task_type: &str,
@@ -975,7 +973,8 @@ fn emit_active_subtasks(
             parsed: json,
         });
     }
-    if let Some(app) = app {
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state.app_handle.read().as_ref() {
         let _ = app.emit(
             &format!("pty-parsed-{session_id}"),
             &parsed,
@@ -1114,7 +1113,6 @@ fn spawn_silence_timer(
     running: Arc<AtomicBool>,
     session_id: String,
     state: Arc<AppState>,
-    app: Option<AppHandle>,
 ) {
     let event_bus = state.event_bus.clone();
     tokio::spawn(async move {
@@ -1142,9 +1140,9 @@ fn spawn_silence_timer(
                         // but the frontend store only learns from this stream.
                         // Without an explicit count=0 emission, the UI keeps a
                         // non-zero badge and notifications stay suppressed.
-                        emit_active_subtasks(&state, app.as_ref(), &session_id, 0, "");
+                        emit_active_subtasks(&state, &session_id, 0, "");
                     }
-                    emit_shell_state(&state, app.as_ref(), &session_id, "idle");
+                    emit_shell_state(&state, &session_id, "idle");
                     record_inferred_outcome_if_no_osc133(&state, &session_id);
                 }
             }
@@ -1163,7 +1161,8 @@ fn spawn_silence_timer(
             if let Some(text) = silence.lock().check_tool_error() {
                 let parsed = ParsedEvent::ToolError { matched_text: text };
                 if let Ok(json) = serde_json::to_value(&parsed) {
-                    if let Some(ref app) = app {
+                    #[cfg(feature = "desktop")]
+                    if let Some(app) = state.app_handle.read().as_ref() {
                         let _ = app.emit(
                             &format!("pty-parsed-{session_id}"),
                             &json,
@@ -1189,7 +1188,8 @@ fn spawn_silence_timer(
             {
                 let parsed = ParsedEvent::Suggest { items };
                 if let Ok(json) = serde_json::to_value(&parsed) {
-                    if let Some(ref app) = app {
+                    #[cfg(feature = "desktop")]
+                    if let Some(app) = state.app_handle.read().as_ref() {
                         let _ = app.emit(
                             &format!("pty-parsed-{session_id}"),
                             &json,
@@ -1268,7 +1268,8 @@ fn spawn_silence_timer(
                 confident: false,
             };
             if let Ok(json) = serde_json::to_value(&parsed) {
-                if let Some(ref app) = app {
+                #[cfg(feature = "desktop")]
+                if let Some(app) = state.app_handle.read().as_ref() {
                     let _ = app.emit(
                         &format!("pty-parsed-{session_id}"),
                         &json,
@@ -1289,7 +1290,7 @@ fn spawn_silence_timer(
 
 /// Per-session mutable state for processing PTY output chunks.
 /// Holds dedup state, parser, and session CWD for PlanFile resolution.
-/// Used by both `spawn_reader_thread` (desktop) and `spawn_headless_reader_thread`.
+/// Used by `spawn_reader_thread`.
 struct ChunkProcessor {
     parser: OutputParser,
     /// Dedup: only emit StatusLine when task_name actually changes
@@ -1373,19 +1374,18 @@ impl ChunkProcessor {
         payload: &str,
         session_id: &str,
         state: &AppState,
-        app: Option<&tauri::AppHandle>,
     ) {
         let (target, label) = match payload {
             "idle" => (SHELL_IDLE, "idle"),
             "busy" => (SHELL_BUSY, "busy"),
             _ => return,
         };
-        transition_shell_state(state, app, session_id, target, label);
+        transition_shell_state(state, session_id, target, label);
     }
 
     /// Handle a single OSC 133 event from the VTE handler.
     /// On 'C' captures the command text; on 'D' builds a `CommandOutcome`.
-    fn handle_osc133_event(&mut self, command: char, params: &str, session_id: &str, state: &AppState, app: Option<&tauri::AppHandle>) {
+    fn handle_osc133_event(&mut self, command: char, params: &str, session_id: &str, state: &AppState) {
         use crate::ai_agent::knowledge::{
             classify_error, CommandOutcome, OutcomeClass, SessionKnowledge,
         };
@@ -1395,10 +1395,10 @@ impl ChunkProcessor {
         // These bypass the silence timer entirely when OSC 133 is available.
         match command {
             'A' => {
-                transition_shell_state(state, app, session_id, SHELL_IDLE, "idle");
+                transition_shell_state(state, session_id, SHELL_IDLE, "idle");
             }
             'C' => {
-                transition_shell_state(state, app, session_id, SHELL_BUSY, "busy");
+                transition_shell_state(state, session_id, SHELL_BUSY, "busy");
                 let cmd = state
                     .input_buffers
                     .get(session_id)
@@ -1586,7 +1586,6 @@ impl ChunkProcessor {
         &mut self,
         session_id: &str,
         state: &AppState,
-        app: Option<&AppHandle>,
     ) {
         if self.pending_planfiles.is_empty() {
             return;
@@ -1610,7 +1609,8 @@ impl ChunkProcessor {
                         session_id: session_id.to_string(),
                         parsed: json.clone(),
                     });
-                    if let Some(a) = app {
+                    #[cfg(feature = "desktop")]
+                    if let Some(a) = state.app_handle.read().as_ref() {
                         let _ = a.emit("pty-parsed", serde_json::json!({
                             "session_id": session_id,
                             "parsed": json,
@@ -1636,14 +1636,13 @@ impl ChunkProcessor {
         silence: &Arc<Mutex<SilenceState>>,
         session_id: &str,
         state: &AppState,
-        app: Option<&AppHandle>,
     ) -> Option<String> {
         if data.is_empty() {
             return None;
         }
 
         // Check pending plan files: emit if file appeared, drop if deadline expired.
-        self.check_pending_planfiles(session_id, state, app);
+        self.check_pending_planfiles(session_id, state);
 
         // Feed raw data (post-kitty-strip) into VT100 log buffer.
         // Also capture the post-process `total_lines` and `oldest_offset` so
@@ -1697,15 +1696,14 @@ impl ChunkProcessor {
                 .last_vt_log_emit
                 .map(|t| t.elapsed() >= std::time::Duration::from_millis(100))
                 .unwrap_or(true);
-            if should_emit
-                && let Some(a) = app
-            {
-                // Emit as a bare number — wrapping in an object corrupts
-                // the cache's internal counter (Tauri serialization issue).
-                let _ = a.emit(
-                    &format!("pty-vt-log-total-{session_id}"),
-                    new_total,
-                );
+            if should_emit {
+                #[cfg(feature = "desktop")]
+                if let Some(a) = state.app_handle.read().as_ref() {
+                    let _ = a.emit(
+                        &format!("pty-vt-log-total-{session_id}"),
+                        new_total,
+                    );
+                }
                 self.last_vt_log_emit = Some(std::time::Instant::now());
             }
             self.last_vt_log_total = new_total;
@@ -1735,24 +1733,28 @@ impl ChunkProcessor {
                         }
                     }
                     TermEvent::Title(title) => {
-                        if let Some(a) = app {
+                        #[cfg(feature = "desktop")]
+                        if let Some(a) = state.app_handle.read().as_ref() {
                             let _ = a.emit(&format!("pty-title-{session_id}"), &title);
                         }
                     }
                     TermEvent::ResetTitle => {
-                        if let Some(a) = app {
+                        #[cfg(feature = "desktop")]
+                        if let Some(a) = state.app_handle.read().as_ref() {
                             let _ = a.emit(&format!("pty-title-{session_id}"), "");
                         }
                     }
                     TermEvent::ClipboardStore(text) => {
-                        if let Some(a) = app {
+                        #[cfg(feature = "desktop")]
+                        if let Some(a) = state.app_handle.read().as_ref() {
                             let _ = a.emit(&format!("pty-clipboard-store-{session_id}"), &text);
                         }
                     }
                     TermEvent::Osc133 { command, params, line } => {
                         state.has_osc133_integration.insert(session_id.to_string(), ());
-                        self.handle_osc133_event(command, &params, session_id, state, app);
-                        if let Some(a) = app {
+                        self.handle_osc133_event(command, &params, session_id, state);
+                        #[cfg(feature = "desktop")]
+                        if let Some(a) = state.app_handle.read().as_ref() {
                             let _ = a.emit(
                                 &format!("pty-osc133-{session_id}"),
                                 &Osc133Event { marker: command.to_string(), line, exit_code: parse_osc133_exit_code(command, &params) },
@@ -1764,7 +1766,8 @@ impl ChunkProcessor {
                             if let Some(entry) = state.sessions.get(session_id) {
                                 entry.lock().cwd = Some(cwd.clone());
                             }
-                            if let Some(a) = app {
+                            #[cfg(feature = "desktop")]
+                            if let Some(a) = state.app_handle.read().as_ref() {
                                 let _ = a.emit(&format!("pty-cwd-{session_id}"), &cwd);
                             }
                         }
@@ -1772,7 +1775,7 @@ impl ChunkProcessor {
                     TermEvent::Tuic { verb, payload } => {
                         match verb.as_str() {
                             "state" => {
-                                self.handle_tuic_state(&payload, session_id, state, app);
+                                self.handle_tuic_state(&payload, session_id, state);
                             }
                             "suggest" => {
                                 let items: Vec<String> = payload.split('|').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
@@ -1983,14 +1986,13 @@ impl ChunkProcessor {
 
             // Serialize once, reuse for both broadcast and Tauri IPC
             if let Ok(json) = serde_json::to_value(emit_event) {
-                // Tauri IPC for desktop mode (emit the pre-serialized Value)
-                if let Some(app) = app {
+                #[cfg(feature = "desktop")]
+                if let Some(app) = state.app_handle.read().as_ref() {
                     let _ = app.emit(
                         &format!("pty-parsed-{session_id}"),
                         &json,
                     );
                 }
-                // Broadcast to SSE/WebSocket consumers
                 let _ = state.event_bus.send(crate::state::AppEvent::PtyParsed {
                     session_id: session_id.to_string(),
                     parsed: json,
@@ -2082,7 +2084,7 @@ impl ChunkProcessor {
             if prev != SHELL_BUSY
                 && try_shell_transition(state, session_id, prev, SHELL_BUSY, true)
             {
-                emit_shell_state(state, app, session_id, "busy");
+                emit_shell_state(state, session_id, "busy");
             }
         }
 
@@ -2114,7 +2116,6 @@ fn process_kitty_actions(
     kitty_actions: &[KittyAction],
     session_id: &str,
     state: &AppState,
-    app: Option<&AppHandle>,
 ) {
     if kitty_actions.is_empty() {
         return;
@@ -2147,7 +2148,8 @@ fn process_kitty_actions(
     }
     let flags = ks.current_flags();
     drop(ks);
-    if let Some(app) = app {
+    #[cfg(feature = "desktop")]
+    if let Some(app) = state.app_handle.read().as_ref() {
         let _ = app.emit(
             &format!("kitty-keyboard-{session_id}"),
             flags,
@@ -2617,30 +2619,26 @@ fn clamp_cursor_up(data: &str, max_rows: u16) -> String {
     result
 }
 
-/// Spawn a reader thread that reads from a PTY, emits Tauri events, and writes to the ring buffer.
-/// Shared by `create_pty`, `create_pty_with_worktree`, and `spawn_agent` to avoid duplication.
+/// Spawn a reader thread that reads from a PTY, processes output, and emits events.
+/// Unified for both desktop (Tauri IPC) and headless (event_bus only) modes.
 pub(crate) fn spawn_reader_thread(
     mut reader: Box<dyn Read + Send>,
     paused: Arc<AtomicBool>,
     session_id: String,
-    app: AppHandle,
     state: Arc<AppState>,
     tuic_session: Option<String>,
 ) {
     let silence = Arc::new(Mutex::new(SilenceState::new()));
     let running = Arc::new(AtomicBool::new(true));
 
-    // Register in AppState so write_pty can suppress user-typed question lines
     state.silence_states.insert(session_id.clone(), silence.clone());
     state.shell_states.insert(session_id.clone(), std::sync::atomic::AtomicU8::new(SHELL_NULL));
 
-    // Spawn silence-detection timer thread
     spawn_silence_timer(
         silence.clone(),
         running.clone(),
         session_id.clone(),
         state.clone(),
-        Some(app.clone()),
     );
 
     std::thread::spawn(move || {
@@ -2676,9 +2674,9 @@ pub(crate) fn spawn_reader_thread(
                     }
                     let data = kitty_clean;
 
-                    process_kitty_actions(&kitty_actions, &session_id, &state, Some(&app));
+                    process_kitty_actions(&kitty_actions, &session_id, &state);
 
-                    if let Some(processed) = processor.process_chunk(&data, &silence, &session_id, &state, Some(&app))
+                    if let Some(processed) = processor.process_chunk(&data, &silence, &session_id, &state)
                         && let Some(xterm_data) = processor.transform_xterm(processed)
                     {
                         let clamped_data = xterm_data;
@@ -2693,18 +2691,18 @@ pub(crate) fn spawn_reader_thread(
                             }
                         }
 
-                        let _ = app.emit(
-                            &format!("pty-output-{session_id}"),
-                            PtyOutput {
-                                session_id: session_id.clone(),
-                                data: clamped_data,
-                            },
-                        );
+                        #[cfg(feature = "desktop")]
+                        if let Some(app) = state.app_handle.read().as_ref() {
+                            let _ = app.emit(
+                                &format!("pty-output-{session_id}"),
+                                PtyOutput {
+                                    session_id: session_id.clone(),
+                                    data: clamped_data,
+                                },
+                            );
+                        }
                     }
 
-                    // Send grid frame if the frontend has acked the previous one.
-                    // When in-flight, damage accumulates in alacritty's grid and
-                    // the next frame will carry all pending changes (natural coalescing).
                     let in_flight = state.grid_frame_in_flight.get(&session_id)
                         .map(|f| f.load(std::sync::atomic::Ordering::Relaxed))
                         .unwrap_or(false);
@@ -2721,47 +2719,51 @@ pub(crate) fn spawn_reader_thread(
                 }
             }
         }
-        // Signal timer thread to stop
         running.store(false, Ordering::Relaxed);
 
-        // Ensure shell state is idle on session end (frontend indicator only).
-        // notify_parent=false: mark_session_exited sends the sole "exited" notification.
         if try_shell_transition(&state, &session_id, SHELL_BUSY, SHELL_IDLE, false) {
-            emit_shell_state(&state, Some(&app), &session_id, "idle");
+            emit_shell_state(&state, &session_id, "idle");
         }
 
-        // Flush remaining bytes at EOF
         let remaining = flush_eof(&mut utf8_buf, &mut esc_buf, &session_id, &state);
+        #[cfg(feature = "desktop")]
         if !remaining.is_empty() {
-            let _ = app.emit(
-                &format!("pty-output-{session_id}"),
-                PtyOutput {
-                    session_id: session_id.clone(),
-                    data: remaining,
-                },
-            );
+            if let Some(app) = state.app_handle.read().as_ref() {
+                let _ = app.emit(
+                    &format!("pty-output-{session_id}"),
+                    PtyOutput {
+                        session_id: session_id.clone(),
+                        data: remaining,
+                    },
+                );
+            }
         }
 
-        // Broadcast exit events
         let _ = state.event_bus.send(crate::state::AppEvent::PtyExit {
             session_id: session_id.clone(),
         });
-        let _ = app.emit(
-            &format!("pty-exit-{session_id}"),
-            serde_json::json!({ "session_id": session_id }),
-        );
+        #[cfg(feature = "desktop")]
+        if let Some(app) = state.app_handle.read().as_ref() {
+            let _ = app.emit(
+                &format!("pty-exit-{session_id}"),
+                serde_json::json!({ "session_id": session_id }),
+            );
+        }
         tracing::info!(source = "pty", session_id = %session_id, "Session closed: process exited");
         let _ = state.event_bus.send(crate::state::AppEvent::SessionClosed {
             session_id: session_id.clone(),
             reason: "process_exit".to_string(),
         });
-        let agent_type = state.session_states.get(&session_id)
-            .and_then(|s| s.agent_type.clone());
-        let _ = app.emit("session-closed", serde_json::json!({
-            "session_id": session_id,
-            "reason": "process_exit",
-            "agent_type": agent_type,
-        }));
+        #[cfg(feature = "desktop")]
+        if let Some(app) = state.app_handle.read().as_ref() {
+            let agent_type = state.session_states.get(&session_id)
+                .and_then(|s| s.agent_type.clone());
+            let _ = app.emit("session-closed", serde_json::json!({
+                "session_id": session_id,
+                "reason": "process_exit",
+                "agent_type": agent_type,
+            }));
+        }
 
         mark_session_exited(&session_id, &state);
         })); // end catch_unwind
@@ -2779,99 +2781,11 @@ pub(crate) fn spawn_reader_thread(
     });
 }
 
-/// Reader thread for sessions created via HTTP (no AppHandle available).
-/// Writes to ring buffer only — MCP consumers poll via GET /sessions/{id}/output.
-pub(crate) fn spawn_headless_reader_thread(
-    mut reader: Box<dyn Read + Send>,
-    paused: Arc<AtomicBool>,
-    session_id: String,
-    state: Arc<AppState>,
-) {
-    let silence = Arc::new(Mutex::new(SilenceState::new()));
-    let running = Arc::new(AtomicBool::new(true));
-
-    state.silence_states.insert(session_id.clone(), silence.clone());
-    state.shell_states.insert(session_id.clone(), std::sync::atomic::AtomicU8::new(SHELL_NULL));
-
-    // Spawn silence-detection timer (headless: event_bus only, no Tauri IPC)
-    spawn_silence_timer(
-        silence.clone(),
-        running.clone(),
-        session_id.clone(),
-        state.clone(),
-        None,
-    );
-
-    std::thread::spawn(move || {
-        let mut buf = [0u8; 65536];
-        let mut utf8_buf = Utf8ReadBuffer::new();
-        let mut esc_buf = EscapeAwareBuffer::new();
-        let session_cwd: Option<String> = state
-            .sessions
-            .get(&session_id)
-            .and_then(|s| s.lock().cwd.clone());
-        let mut processor = ChunkProcessor::new(session_cwd, None);
-        loop {
-            while paused.load(Ordering::Relaxed) {
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
-            match reader.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    state.metrics.bytes_emitted.fetch_add(n, Ordering::Relaxed);
-                    let utf8_data = utf8_buf.push(&buf[..n]);
-                    let esc_data = esc_buf.push(&utf8_data);
-                    let (kitty_clean, kitty_actions) = strip_kitty_sequences(&esc_data);
-                    let data = kitty_clean;
-
-                    process_kitty_actions(&kitty_actions, &session_id, &state, None);
-
-                    // Headless: no xterm output — just process for events and state
-                    processor.process_chunk(&data, &silence, &session_id, &state, None);
-                }
-                Err(e) => {
-                    tracing::error!(session_id = %session_id, "PTY reader error: {e}");
-                    break;
-                }
-            }
-        }
-        // Signal silence timer thread to stop
-        running.store(false, Ordering::Relaxed);
-
-        // Ensure shell state is idle on session end (frontend indicator only).
-        // notify_parent=false: mark_session_exited sends the sole "exited" notification.
-        if try_shell_transition(&state, &session_id, SHELL_BUSY, SHELL_IDLE, false) {
-            emit_shell_state(&state, None, &session_id, "idle");
-        }
-
-        // Flush remaining bytes at EOF
-        flush_eof(&mut utf8_buf, &mut esc_buf, &session_id, &state);
-
-        // Broadcast exit so SSE/WebSocket consumers and Tauri frontend can clean up
-        tracing::info!(source = "pty", session_id = %session_id, "Headless session closed: process exited");
-        let _ = state.event_bus.send(crate::state::AppEvent::SessionClosed {
-            session_id: session_id.clone(),
-            reason: "process_exit".to_string(),
-        });
-        if let Some(app) = state.app_handle.read().as_ref() {
-            let agent_type = state.session_states.get(&session_id)
-                .and_then(|s| s.agent_type.clone());
-            let _ = app.emit("session-closed", serde_json::json!({
-                "session_id": session_id,
-                "reason": "process_exit",
-                "agent_type": agent_type,
-            }));
-        }
-
-        mark_session_exited(&session_id, &state);
-    });
-}
-
 /// Create a new PTY session with optional worktree
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn create_pty(
-    app: AppHandle,
+    _app: AppHandle,
     state: State<'_, Arc<AppState>>,
     config: PtyConfig,
 ) -> Result<String, String> {
@@ -3006,7 +2920,6 @@ pub(crate) async fn create_pty(
         reader,
         paused,
         session_id.clone(),
-        app,
         state.inner().clone(),
         tuic_session,
     );
@@ -3021,12 +2934,6 @@ pub(crate) async fn spawn_session_for_agent(
     cwd: Option<String>,
     display_name: Option<String>,
 ) -> Result<String, String> {
-    let app = state
-        .app_handle
-        .read()
-        .clone()
-        .ok_or_else(|| "AppHandle not available".to_string())?;
-
     let session_id = Uuid::new_v4().to_string();
     let pty_system = native_pty_system();
     let rows: u16 = 24;
@@ -3102,13 +3009,14 @@ pub(crate) async fn spawn_session_for_agent(
         cwd: state.sessions.get(&session_id).and_then(|s| s.lock().cwd.clone()),
         agent_type: None,
     });
+    #[cfg(feature = "desktop")]
     if let Some(ref a) = *state.app_handle.read() {
         let _ = a.emit("session-created", serde_json::json!({
             "session_id": session_id,
         }));
     }
 
-    spawn_reader_thread(reader, paused, session_id.clone(), app, state.clone(), None);
+    spawn_reader_thread(reader, paused, session_id.clone(), state.clone(), None);
 
     Ok(session_id)
 }
@@ -3117,7 +3025,7 @@ pub(crate) async fn spawn_session_for_agent(
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) async fn create_pty_with_worktree(
-    app: AppHandle,
+    _app: AppHandle,
     state: State<'_, Arc<AppState>>,
     pty_config: PtyConfig,
     worktree_config: WorktreeConfig,
@@ -3241,7 +3149,6 @@ pub(crate) async fn create_pty_with_worktree(
         reader,
         paused,
         session_id.clone(),
-        app,
         state.inner().clone(),
         None,
     );
@@ -6329,7 +6236,7 @@ mod tests {
 
         // Subscribe BEFORE emitting so the broadcast is captured.
         let mut rx = state.event_bus.subscribe();
-        emit_active_subtasks(&state, None, sid, 0, "");
+        emit_active_subtasks(&state, sid, 0, "");
 
         let event = rx.try_recv().expect("event bus must receive PtyParsed");
         match event {
@@ -6573,7 +6480,7 @@ mod tests {
         let raw = b"* Reading files...";
         let utf8_data = utf8_buf.push(raw);
         let esc_data = esc_buf.push(&utf8_data);
-        let result1 = cp.process_chunk(&esc_data, &silence, sid, &state, None);
+        let result1 = cp.process_chunk(&esc_data, &silence, sid, &state);
 
         // Count how many PtyParsed events were sent with StatusLine
         let mut rx = state.event_bus.subscribe();
@@ -6581,7 +6488,7 @@ mod tests {
         let raw2 = b"\r\n* Reading files...";
         let utf8_data2 = utf8_buf.push(raw2);
         let esc_data2 = esc_buf.push(&utf8_data2);
-        let _result2 = cp.process_chunk(&esc_data2, &silence, sid, &state, None);
+        let _result2 = cp.process_chunk(&esc_data2, &silence, sid, &state);
 
         // Collect events from the second call
         let mut status_count = 0;
@@ -6626,7 +6533,7 @@ mod tests {
               Esc to cancel \xc2\xb7 Tab to amend\r\n";
         let utf8_data = utf8_buf.push(screen_bytes);
         let esc_data = esc_buf.push(&utf8_data);
-        let _ = cp.process_chunk(&esc_data, &silence, sid, &state, None);
+        let _ = cp.process_chunk(&esc_data, &silence, sid, &state);
 
         // Drain events from the first chunk and count ChoicePrompt emits.
         let mut rx = state.event_bus.subscribe();
@@ -6635,7 +6542,7 @@ mod tests {
         // Same (title, option keys) signature → must be deduped.
         let utf8_data2 = utf8_buf.push(screen_bytes);
         let esc_data2 = esc_buf.push(&utf8_data2);
-        let _ = cp.process_chunk(&esc_data2, &silence, sid, &state, None);
+        let _ = cp.process_chunk(&esc_data2, &silence, sid, &state);
 
         let mut choice_count = 0;
         while let Ok(evt) = rx.try_recv() {
@@ -7335,13 +7242,13 @@ mod tests {
         );
 
         let proc = ChunkProcessor::new(None, None);
-        proc.handle_tuic_state("busy", session_id, &state, None);
+        proc.handle_tuic_state("busy", session_id, &state);
 
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);
         assert_eq!(current, SHELL_BUSY);
 
-        proc.handle_tuic_state("idle", session_id, &state, None);
+        proc.handle_tuic_state("idle", session_id, &state);
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);
         assert_eq!(current, SHELL_IDLE);
@@ -7363,7 +7270,7 @@ mod tests {
         let mut rx = state.event_bus.subscribe();
 
         let proc = ChunkProcessor::new(None, None);
-        proc.handle_tuic_state("busy", session_id, &state, None);
+        proc.handle_tuic_state("busy", session_id, &state);
 
         let evt = rx.try_recv();
         assert!(evt.is_ok(), "event_bus should have received a shell state event");
@@ -7386,7 +7293,7 @@ mod tests {
         );
 
         let proc = ChunkProcessor::new(None, None);
-        proc.handle_tuic_state("thinking", session_id, &state, None);
+        proc.handle_tuic_state("thinking", session_id, &state);
 
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);
@@ -7408,7 +7315,7 @@ mod tests {
         state.has_osc133_integration.insert(session_id.to_string(), ());
 
         let mut proc = ChunkProcessor::new(None, None);
-        proc.handle_osc133_event('A', "", session_id, &state, None);
+        proc.handle_osc133_event('A', "", session_id, &state);
 
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);
@@ -7430,7 +7337,7 @@ mod tests {
         state.has_osc133_integration.insert(session_id.to_string(), ());
 
         let mut proc = ChunkProcessor::new(None, None);
-        proc.handle_osc133_event('C', "", session_id, &state, None);
+        proc.handle_osc133_event('C', "", session_id, &state);
 
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);
@@ -7454,7 +7361,7 @@ mod tests {
         let mut rx = state.event_bus.subscribe();
 
         let mut proc = ChunkProcessor::new(None, None);
-        proc.handle_osc133_event('A', "", session_id, &state, None);
+        proc.handle_osc133_event('A', "", session_id, &state);
 
         // Check event_bus received a state change
         let evt = rx.try_recv();
@@ -7484,7 +7391,7 @@ mod tests {
         state.has_osc133_integration.insert(session_id.to_string(), ());
 
         let mut proc = ChunkProcessor::new(None, None);
-        proc.handle_osc133_event('D', "0", session_id, &state, None);
+        proc.handle_osc133_event('D', "0", session_id, &state);
 
         let current = state.shell_states.get(session_id).unwrap()
             .load(std::sync::atomic::Ordering::Acquire);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1762,6 +1762,7 @@ impl ChunkProcessor {
                         }
                     }
                     TermEvent::Osc7(url) => {
+                        #[allow(clippy::collapsible_if)]
                         if let Ok(cwd) = parse_osc7_cwd(&url) {
                             if let Some(entry) = state.sessions.get(session_id) {
                                 entry.lock().cwd = Some(cwd.clone());
@@ -2729,16 +2730,14 @@ pub(crate) fn spawn_reader_thread(
 
         let remaining = flush_eof(&mut utf8_buf, &mut esc_buf, &session_id, &state);
         #[cfg(feature = "desktop")]
-        if !remaining.is_empty() {
-            if let Some(app) = state.app_handle.read().as_ref() {
-                let _ = app.emit(
-                    &format!("pty-output-{session_id}"),
-                    PtyOutput {
-                        session_id: session_id.clone(),
-                        data: remaining,
-                    },
-                );
-            }
+        if !remaining.is_empty() && let Some(app) = state.app_handle.read().as_ref() {
+            let _ = app.emit(
+                &format!("pty-output-{session_id}"),
+                PtyOutput {
+                    session_id: session_id.clone(),
+                    data: remaining,
+                },
+            );
         }
 
         let _ = state.event_bus.send(crate::state::AppEvent::PtyExit {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -32,7 +32,7 @@ pub struct RegistryEntry {
 ///
 /// Returns the parsed list of registry entries or an error string.
 /// The caller (TypeScript store) is responsible for caching / TTL.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub async fn fetch_plugin_registry() -> Result<Vec<RegistryEntry>, String> {
     fetch_registry_from(DEFAULT_REGISTRY_URL).await
 }

--- a/src-tauri/src/repo_watcher.rs
+++ b/src-tauri/src/repo_watcher.rs
@@ -343,13 +343,13 @@ pub(crate) fn stop_watching(repo_path: &str, state: &Arc<AppState>) {
 
 // --- Tauri commands ---
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn start_repo_watcher(repo_path: String, app_handle: AppHandle) -> Result<(), String> {
     let state = app_handle.state::<Arc<AppState>>();
     start_watching(&repo_path, Some(&app_handle), &state)
 }
 
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn stop_repo_watcher(repo_path: String, app_handle: AppHandle) {
     let state = app_handle.state::<Arc<AppState>>();
     stop_watching(&repo_path, &state);

--- a/src-tauri/src/repo_watcher.rs
+++ b/src-tauri/src/repo_watcher.rs
@@ -4,6 +4,7 @@ use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, Manager};
 use crate::state::AppEvent;
 use crate::AppState;
@@ -192,7 +193,6 @@ pub(crate) struct WatchHandle(#[allow(dead_code)] pub(crate) Mutex<RecommendedWa
 /// a synchronous walkdir+stat scan at registration time.
 pub(crate) fn start_watching(
     repo_path: &str,
-    app_handle: Option<&AppHandle>,
     state: &Arc<AppState>,
 ) -> Result<(), String> {
     // Don't double-watch
@@ -206,30 +206,24 @@ pub(crate) fn start_watching(
     let gitignore = Arc::new(parking_lot::RwLock::new(build_gitignore(&repo)));
 
     let repo_path_owned = repo_path.to_string();
-    let handle = app_handle.cloned();
+    #[cfg(feature = "desktop")]
+    let handle = state.app_handle.read().clone();
     let event_bus = state.event_bus.clone();
     let state_cb = Arc::clone(state);
     let emitter = Arc::new(CategoryEmitter::new(
-        tauri::async_runtime::handle().inner().clone(),
+        tokio::runtime::Handle::current(),
     ));
 
     let repo_for_cb = repo.clone();
     let git_dir_for_cb = git_dir.clone();
     let gitignore_cb = Arc::clone(&gitignore);
 
-    // Raw notify watcher — no debouncer-full, no walkdir scan.
-    // Each OS event is classified and fed to CategoryEmitter which
-    // handles per-category trailing debounce.
     let mut watcher = notify::recommended_watcher(
         move |result: Result<notify::Event, notify::Error>| {
             let event = match result {
                 Ok(e) => e,
                 Err(err) => {
-                    if let Some(ref handle) = handle {
-                        crate::app_logger::log_via_handle(handle, "warn", "app", &format!("[repo_watcher] error for {repo_path_owned}: {err}"));
-                    } else {
-                        tracing::warn!(source = "repo_watcher", path = %repo_path_owned, "Watcher error: {err}");
-                    }
+                    tracing::warn!(source = "repo_watcher", path = %repo_path_owned, "Watcher error: {err}");
                     return;
                 }
             };
@@ -263,6 +257,7 @@ pub(crate) fn start_watching(
                 let repo_path = repo_path_owned.clone();
                 let repo = repo_for_cb.clone();
                 let bus = event_bus.clone();
+                #[cfg(feature = "desktop")]
                 let h = handle.clone();
                 emitter.trigger(&EventCategory::Head, move || {
                     if let Some(branch) = crate::git::read_branch_from_head(&repo) {
@@ -270,6 +265,7 @@ pub(crate) fn start_watching(
                             repo_path: repo_path.clone(),
                             branch: branch.clone(),
                         });
+                        #[cfg(feature = "desktop")]
                         if let Some(ref handle) = h {
                             let _ = handle.emit(
                                 "head-changed",
@@ -283,6 +279,7 @@ pub(crate) fn start_watching(
             if has_git_state {
                 let repo_path = repo_path_owned.clone();
                 let bus = event_bus.clone();
+                #[cfg(feature = "desktop")]
                 let h = handle.clone();
                 let st = Arc::clone(&state_cb);
                 emitter.trigger(&EventCategory::GitState, move || {
@@ -290,6 +287,7 @@ pub(crate) fn start_watching(
                     let _ = bus.send(AppEvent::RepoChanged {
                         repo_path: repo_path.clone(),
                     });
+                    #[cfg(feature = "desktop")]
                     if let Some(ref handle) = h {
                         let _ = handle.emit(
                             "repo-changed",
@@ -299,12 +297,10 @@ pub(crate) fn start_watching(
                 });
             }
 
-            // Only emit WorkingTree if GitState didn't already fire in this event.
-            // A git operation (commit, stage) already triggers RepoChanged via GitState
-            // at 500ms — emitting again at 1500ms would double-fire githubStore.pollRepo.
             if has_working_tree && !has_git_state {
                 let repo_path = repo_path_owned.clone();
                 let bus = event_bus.clone();
+                #[cfg(feature = "desktop")]
                 let h = handle.clone();
                 let st = Arc::clone(&state_cb);
                 emitter.trigger(&EventCategory::WorkingTree, move || {
@@ -312,6 +308,7 @@ pub(crate) fn start_watching(
                     let _ = bus.send(AppEvent::RepoChanged {
                         repo_path: repo_path.clone(),
                     });
+                    #[cfg(feature = "desktop")]
                     if let Some(ref handle) = h {
                         let _ = handle.emit(
                             "repo-changed",
@@ -343,13 +340,15 @@ pub(crate) fn stop_watching(repo_path: &str, state: &Arc<AppState>) {
 
 // --- Tauri commands ---
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub(crate) fn start_repo_watcher(repo_path: String, app_handle: AppHandle) -> Result<(), String> {
     let state = app_handle.state::<Arc<AppState>>();
-    start_watching(&repo_path, Some(&app_handle), &state)
+    start_watching(&repo_path, &state)
 }
 
-#[cfg_attr(feature = "desktop", tauri::command)]
+#[cfg(feature = "desktop")]
+#[tauri::command]
 pub(crate) fn stop_repo_watcher(repo_path: String, app_handle: AppHandle) {
     let state = app_handle.state::<Arc<AppState>>();
     stop_watching(&repo_path, &state);

--- a/src-tauri/src/smart_prompt.rs
+++ b/src-tauri/src/smart_prompt.rs
@@ -59,7 +59,7 @@ fn format_process_error(output: &Output) -> String {
 /// interpolation is performed, so characters like `;`, `&&`, backticks or `$()` in
 /// args are passed to the child process verbatim. `stdin_content` is piped to the
 /// process stdin to convey prompt content. Timeout is capped at 5 minutes.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn execute_headless_prompt(
     command: String,
     args: Vec<String>,
@@ -120,7 +120,7 @@ pub(crate) async fn execute_headless_prompt(
 /// Unlike `execute_headless_prompt` (which runs a CLI agent command and pipes content
 /// via stdin), this executes `script_content` itself as a shell script — no agent involved.
 /// Timeout is capped at 60 seconds.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) async fn execute_shell_script(
     script_content: String,
     timeout_ms: u64,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1047,6 +1047,102 @@ pub struct AppState {
 }
 
 impl AppState {
+    pub fn new(
+        data_dir: PathBuf,
+        worktrees_dir: PathBuf,
+        config: crate::config::AppConfig,
+        log_buffer: Arc<Mutex<crate::app_logger::LogRingBuffer>>,
+    ) -> Self {
+        let mcp_upstream_registry = Arc::new(crate::mcp_proxy::registry::UpstreamRegistry::new());
+        let session_token = config.session_token.clone();
+        let push_store = crate::push::PushStore::load(&data_dir);
+        Self {
+            sessions: DashMap::new(),
+            data_dir,
+            worktrees_dir,
+            metrics: SessionMetrics::new(),
+            output_buffers: DashMap::new(),
+            mcp_sessions: DashMap::new(),
+            ws_clients: DashMap::new(),
+            config: parking_lot::RwLock::new(config),
+            git_cache: GitCacheState::new(),
+            repo_watchers: DashMap::new(),
+            dir_watchers: DashMap::new(),
+            http_client: reqwest::Client::new(),
+            github_token: parking_lot::RwLock::new(None),
+            github_token_source: parking_lot::RwLock::new(Default::default()),
+            github_circuit_breaker: crate::github::GitHubCircuitBreaker::new(),
+            github_poller: parking_lot::Mutex::new(None),
+            github_viewer_login: parking_lot::RwLock::new(None),
+            github_rate_limit_remaining: std::sync::atomic::AtomicU32::new(u32::MAX),
+            server_shutdown: parking_lot::Mutex::new(None),
+            ipc_started: std::sync::atomic::AtomicBool::new(false),
+            session_token: parking_lot::RwLock::new(session_token),
+            #[cfg(feature = "desktop")]
+            app_handle: parking_lot::RwLock::new(None),
+            plugin_watchers: DashMap::new(),
+            vt_log_buffers: DashMap::new(),
+            #[cfg(feature = "desktop")]
+            grid_channels: DashMap::new(),
+            grid_watch: DashMap::new(),
+            grid_frame_in_flight: DashMap::new(),
+            kitty_states: DashMap::new(),
+            input_buffers: DashMap::new(),
+            last_prompts: DashMap::new(),
+            silence_states: DashMap::new(),
+            claude_usage_cache: parking_lot::Mutex::new(crate::claude_usage::load_cache_from_disk()),
+            log_buffer,
+            event_bus: tokio::sync::broadcast::channel(256).0,
+            event_counter: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            session_states: DashMap::new(),
+            oauth_flow_manager: Arc::new(crate::mcp_oauth::flow::OAuthFlowManager::new(
+                mcp_upstream_registry.auth_semaphore.clone(),
+            )),
+            mcp_upstream_registry,
+            mcp_tools_changed: tokio::sync::broadcast::channel(16).0,
+            tool_search_index: Arc::new(parking_lot::RwLock::new(crate::tool_search::ToolSearchIndex::build(&[]))),
+            content_indices: DashMap::new(),
+            indexer_throttle: Arc::new(crate::content_index::IndexerThrottle::default()),
+            slash_mode: DashMap::new(),
+            last_output_ms: DashMap::new(),
+            shell_states: DashMap::new(),
+            terminal_rows: DashMap::new(),
+            exit_codes: DashMap::new(),
+            shell_state_since_ms: DashMap::new(),
+            loaded_plugins: DashMap::new(),
+            relay: RelayState::new(),
+            peer_agents: DashMap::new(),
+            agent_inbox: DashMap::new(),
+            agent_inbox_evictions: DashMap::new(),
+            session_html_tabs: DashMap::new(),
+            mcp_to_session: DashMap::new(),
+            session_to_mcp: DashMap::new(),
+            session_parent: DashMap::new(),
+            messaging_channels: DashMap::new(),
+            session_knowledge: DashMap::new(),
+            knowledge_dirty: DashMap::new(),
+            has_osc133_integration: DashMap::new(),
+            file_sandboxes: DashMap::new(),
+            unrestricted_sessions: DashMap::new(),
+            #[cfg(unix)]
+            bound_socket_path: parking_lot::RwLock::new(std::path::PathBuf::new()),
+            tailscale_state: parking_lot::RwLock::new(crate::tailscale::TailscaleState::NotInstalled),
+            push_store,
+            desktop_window_focused: std::sync::atomic::AtomicBool::new(true),
+            server_start_time: std::time::Instant::now(),
+            term_aliases: DashMap::new(),
+            term_alias_counters: DashMap::new(),
+        }
+    }
+
+    /// Wire event bus and MCP registry after construction.
+    /// Must be called after wrapping in `Arc`.
+    pub fn wire_event_bus(self: &Arc<Self>) {
+        self.mcp_upstream_registry.set_event_bus(self.event_bus.clone());
+        self.mcp_upstream_registry.set_mcp_tools_tx(self.mcp_tools_changed.clone());
+        self.mcp_upstream_registry.set_oauth_flow_manager(self.oauth_flow_manager.clone());
+    }
+
     /// Assign a human-friendly alias based on the repo/cwd name.
     /// E.g. `tuicommander` → `tc-1`, `night-recovery` → `nr-1`, no repo → `sh-1`.
     ///
@@ -2138,86 +2234,20 @@ pub(crate) mod tests_support {
     use super::*;
 
     pub fn make_test_app_state() -> AppState {
-        AppState {
-            sessions: dashmap::DashMap::new(),
-            data_dir: std::env::temp_dir().join("test-tuic-data"),
-            worktrees_dir: std::env::temp_dir().join("test-worktrees"),
-            metrics: SessionMetrics::new(),
-            output_buffers: dashmap::DashMap::new(),
-            mcp_sessions: dashmap::DashMap::new(),
-            ws_clients: dashmap::DashMap::new(),
-            config: parking_lot::RwLock::new(crate::config::AppConfig::default()),
-            git_cache: GitCacheState::new(),
-            repo_watchers: dashmap::DashMap::new(),
-            dir_watchers: dashmap::DashMap::new(),
-            http_client: reqwest::Client::new(),
-            github_token: parking_lot::RwLock::new(None),
-            github_token_source: parking_lot::RwLock::new(Default::default()),
-            github_circuit_breaker: crate::github::GitHubCircuitBreaker::new(),
-            github_poller: parking_lot::Mutex::new(None),
-            github_viewer_login: parking_lot::RwLock::new(None),
-            github_rate_limit_remaining: std::sync::atomic::AtomicU32::new(u32::MAX),
-            server_shutdown: parking_lot::Mutex::new(None),
-            ipc_started: std::sync::atomic::AtomicBool::new(false),
-            session_token: parking_lot::RwLock::new(String::from("test-token")),
-            #[cfg(feature = "desktop")]
-            app_handle: parking_lot::RwLock::new(None),
-            plugin_watchers: dashmap::DashMap::new(),
-            vt_log_buffers: dashmap::DashMap::new(),
-            #[cfg(feature = "desktop")]
-            grid_channels: dashmap::DashMap::new(),
-            grid_watch: dashmap::DashMap::new(),
-            grid_frame_in_flight: dashmap::DashMap::new(),
-            kitty_states: dashmap::DashMap::new(),
-            input_buffers: dashmap::DashMap::new(),
-            last_prompts: dashmap::DashMap::new(),
-            silence_states: dashmap::DashMap::new(),
-            claude_usage_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
-            log_buffer: Arc::new(parking_lot::Mutex::new(crate::app_logger::LogRingBuffer::new(crate::app_logger::LOG_RING_CAPACITY))),
-            event_bus: tokio::sync::broadcast::channel(256).0,
-            event_counter: Arc::new(AtomicU64::new(0)),
-            session_states: DashMap::new(),
-            mcp_upstream_registry: {
-                let r = Arc::new(crate::mcp_proxy::registry::UpstreamRegistry::new());
-                r
-            },
-            oauth_flow_manager: Arc::new(crate::mcp_oauth::flow::OAuthFlowManager::new(
-                Arc::new(tokio::sync::Semaphore::new(1)),
-            )),
-            mcp_tools_changed: tokio::sync::broadcast::channel(16).0,
-            tool_search_index: Arc::new(parking_lot::RwLock::new(crate::tool_search::ToolSearchIndex::build(&[]))),
-            content_indices: DashMap::new(),
-            indexer_throttle: Arc::new(crate::content_index::IndexerThrottle::default()),
-            slash_mode: DashMap::new(),
-            last_output_ms: DashMap::new(),
-            shell_states: DashMap::new(),
-            terminal_rows: DashMap::new(),
-            exit_codes: DashMap::new(),
-            shell_state_since_ms: DashMap::new(),
-            loaded_plugins: DashMap::new(),
-            relay: RelayState::new(),
-            peer_agents: DashMap::new(),
-            agent_inbox: DashMap::new(),
-            agent_inbox_evictions: DashMap::new(),
-            session_html_tabs: DashMap::new(),
-            mcp_to_session: DashMap::new(),
-            session_to_mcp: DashMap::new(),
-            session_parent: DashMap::new(),
-            messaging_channels: DashMap::new(),
-            session_knowledge: DashMap::new(),
-            knowledge_dirty: DashMap::new(),
-            has_osc133_integration: DashMap::new(),
-            file_sandboxes: DashMap::new(),
-            unrestricted_sessions: DashMap::new(),
-            #[cfg(unix)]
-            bound_socket_path: parking_lot::RwLock::new(std::path::PathBuf::new()),
-            tailscale_state: parking_lot::RwLock::new(crate::tailscale::TailscaleState::NotInstalled),
-            push_store: crate::push::PushStore::load(&std::env::temp_dir()),
-            desktop_window_focused: std::sync::atomic::AtomicBool::new(true),
-            server_start_time: std::time::Instant::now(),
-            term_aliases: DashMap::new(),
-            term_alias_counters: DashMap::new(),
-        }
+        let log_buffer = Arc::new(parking_lot::Mutex::new(
+            crate::app_logger::LogRingBuffer::new(crate::app_logger::LOG_RING_CAPACITY),
+        ));
+        let mut state = AppState::new(
+            std::env::temp_dir().join("test-tuic-data"),
+            std::env::temp_dir().join("test-worktrees"),
+            crate::config::AppConfig::default(),
+            log_buffer,
+        );
+        // Override session_token for deterministic tests
+        state.session_token = parking_lot::RwLock::new(String::from("test-token"));
+        // Skip disk I/O for claude_usage in tests
+        state.claude_usage_cache = parking_lot::Mutex::new(std::collections::HashMap::new());
+        state
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter};
 
 // ---------------------------------------------------------------------------
@@ -886,16 +887,14 @@ pub struct AppState {
     /// Browsers auto-send cookies in fetch(), unlike stored Basic Auth credentials.
     /// Behind RwLock so it can be regenerated at runtime (invalidating all sessions).
     pub(crate) session_token: parking_lot::RwLock<String>,
-    /// Tauri AppHandle — stored after setup() so HTTP handlers can emit events.
-    /// None before Tauri initializes (or in headless/test scenarios).
+    #[cfg(feature = "desktop")]
     pub(crate) app_handle: parking_lot::RwLock<Option<AppHandle>>,
     /// Plugin filesystem watchers: watch_id → (plugin_id, watcher)
     pub plugin_watchers: DashMap<String, (String, notify::RecommendedWatcher)>,
     /// Per-session VT100 log buffers for clean mobile/REST output (session_id → buffer).
     /// Separate DashMap to avoid writer contention on PtySession.
     pub(crate) vt_log_buffers: DashMap<String, Mutex<VtLogBuffer>>,
-    /// Active Tauri Channel subscriptions for binary grid streaming (session_id → channel).
-    /// Frontend calls `subscribe_terminal_grid` to register; channel is dropped on session exit.
+    #[cfg(feature = "desktop")]
     pub(crate) grid_channels: DashMap<String, tauri::ipc::Channel<Vec<u8>>>,
     /// Watch channel for WebSocket grid streaming (session_id → sender).
     /// Uses latest-frame-wins semantics: slow WS clients skip intermediate frames.
@@ -1073,6 +1072,7 @@ impl AppState {
         *counter += 1;
         let alias = format!("{prefix}-{}", *counter);
         self.term_aliases.insert(session_id.to_string(), alias.clone());
+        #[cfg(feature = "desktop")]
         if let Some(ref app) = *self.app_handle.read() {
             let _ = app.emit("term-alias-assigned", serde_json::json!({
                 "session_id": session_id,
@@ -2160,9 +2160,11 @@ pub(crate) mod tests_support {
             server_shutdown: parking_lot::Mutex::new(None),
             ipc_started: std::sync::atomic::AtomicBool::new(false),
             session_token: parking_lot::RwLock::new(String::from("test-token")),
+            #[cfg(feature = "desktop")]
             app_handle: parking_lot::RwLock::new(None),
             plugin_watchers: dashmap::DashMap::new(),
             vt_log_buffers: dashmap::DashMap::new(),
+            #[cfg(feature = "desktop")]
             grid_channels: dashmap::DashMap::new(),
             grid_watch: dashmap::DashMap::new(),
             grid_frame_in_flight: dashmap::DashMap::new(),
@@ -2799,9 +2801,11 @@ mod tests {
             server_shutdown: parking_lot::Mutex::new(None),
             ipc_started: std::sync::atomic::AtomicBool::new(false),
             session_token: parking_lot::RwLock::new(String::from("test-token")),
+            #[cfg(feature = "desktop")]
             app_handle: parking_lot::RwLock::new(None),
             plugin_watchers: dashmap::DashMap::new(),
             vt_log_buffers: dashmap::DashMap::new(),
+            #[cfg(feature = "desktop")]
             grid_channels: dashmap::DashMap::new(),
             grid_watch: dashmap::DashMap::new(),
             grid_frame_in_flight: dashmap::DashMap::new(),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -130,6 +130,11 @@ pub enum AppEvent {
         repo_path: String,
         issues: Vec<crate::github::GitHubIssue>,
     },
+    /// Close HTML tabs owned by a session (emitted on session exit)
+    #[serde(rename = "close-html-tabs")]
+    CloseHtmlTabs {
+        tab_ids: Vec<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -831,6 +836,7 @@ pub(crate) const AGENT_MESSAGE_MAX_BYTES: usize = 64 * 1024;
 /// Global state for managing PTY sessions and worktrees
 pub struct AppState {
     pub sessions: DashMap<String, Mutex<PtySession>>,
+    pub(crate) data_dir: PathBuf,
     pub(crate) worktrees_dir: PathBuf,
     pub(crate) metrics: SessionMetrics,
     /// Ring buffers for MCP output access (one per session)
@@ -1592,7 +1598,8 @@ impl AppState {
             | AppEvent::UiTab { .. }
             | AppEvent::GitHubPrUpdate { .. }
             | AppEvent::GitHubTransition { .. }
-            | AppEvent::GitHubIssuesUpdate { .. } => {}
+            | AppEvent::GitHubIssuesUpdate { .. }
+            | AppEvent::CloseHtmlTabs { .. } => {}
         }
     }
 
@@ -2133,6 +2140,7 @@ pub(crate) mod tests_support {
     pub fn make_test_app_state() -> AppState {
         AppState {
             sessions: dashmap::DashMap::new(),
+            data_dir: std::env::temp_dir().join("test-tuic-data"),
             worktrees_dir: std::env::temp_dir().join("test-worktrees"),
             metrics: SessionMetrics::new(),
             output_buffers: dashmap::DashMap::new(),
@@ -2214,6 +2222,14 @@ pub(crate) mod tests_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── data_dir ─────────────────────────────────────────────
+
+    #[test]
+    fn test_state_has_data_dir() {
+        let state = tests_support::make_test_app_state();
+        assert_eq!(state.data_dir, std::env::temp_dir().join("test-tuic-data"));
+    }
 
     // ── split_name_segments ──────────────────────────────────
 
@@ -2763,6 +2779,7 @@ mod tests {
     fn make_test_app_state() -> AppState {
         AppState {
             sessions: dashmap::DashMap::new(),
+            data_dir: std::env::temp_dir().join("test-tuic-data"),
             worktrees_dir: std::env::temp_dir().join("test-worktrees"),
             metrics: SessionMetrics::new(),
             output_buffers: dashmap::DashMap::new(),

--- a/src-tauri/src/tab_shortcut.rs
+++ b/src-tauri/src/tab_shortcut.rs
@@ -17,6 +17,7 @@ pub(crate) fn install(app_handle: tauri::AppHandle) {
     use block2::RcBlock;
     use objc2_app_kit::{NSEvent, NSEventMask, NSEventModifierFlags};
     use std::ptr::{self, NonNull};
+#[cfg(feature = "desktop")]
     use tauri::Emitter;
 
     let block = RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {

--- a/src-tauri/src/tuic_cli.rs
+++ b/src-tauri/src/tuic_cli.rs
@@ -7,6 +7,7 @@
 //! - Tracking whether the first-run prompt has been dismissed
 
 use serde::Serialize;
+#[cfg(feature = "desktop")]
 use tauri::Manager;
 
 #[derive(Serialize)]

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 /// Resolve the effective archive_script for a repo from the three-tier config:
@@ -299,6 +300,7 @@ pub(crate) fn generate_clone_branch_name(source_branch: &str, existing: &[String
 }
 
 /// Create a worktree without a PTY session
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn create_worktree(
     state: State<'_, Arc<AppState>>,
@@ -331,6 +333,7 @@ pub(crate) fn create_worktree(
 
 /// Get worktrees directory path.
 /// When `repo_path` is provided, resolves the effective storage strategy for the repo.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn get_worktrees_dir(state: State<'_, Arc<AppState>>, repo_path: Option<String>) -> String {
     match repo_path {
@@ -390,6 +393,7 @@ pub(crate) fn remove_worktree_by_branch(repo_path: &str, branch_name: &str, dele
 /// Remove a git worktree by branch name (Tauri command with cache invalidation)
 ///
 /// `delete_branch` defaults to `true` when omitted (preserving existing behavior).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn remove_worktree(state: State<'_, Arc<AppState>>, repo_path: String, branch_name: String, delete_branch: Option<bool>) -> Result<(), String> {
     let script = resolve_archive_script(&repo_path);
@@ -403,7 +407,7 @@ pub(crate) fn remove_worktree(state: State<'_, Arc<AppState>>, repo_path: String
 ///
 /// If the branch has a linked worktree, runs `git status --porcelain` in that directory.
 /// If no worktree exists (bare local ref), returns `false` — there's nothing to be dirty.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn check_worktree_dirty(repo_path: String, branch_name: String) -> Result<bool, String> {
     let base_repo = PathBuf::from(&repo_path);
 
@@ -460,6 +464,7 @@ pub(crate) fn delete_local_branch_impl(repo_path: &str, branch_name: &str) -> Re
 }
 
 /// Tauri command: delete a local branch (and its worktree if linked).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn delete_local_branch(state: State<'_, Arc<AppState>>, repo_path: String, branch_name: String) -> Result<(), String> {
     delete_local_branch_impl(&repo_path, &branch_name)?;
@@ -468,7 +473,7 @@ pub(crate) fn delete_local_branch(state: State<'_, Arc<AppState>>, repo_path: St
 }
 
 /// Get worktree paths for a repo: maps branch name -> worktree directory
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn get_worktree_paths(repo_path: String) -> Result<HashMap<String, String>, String> {
     let base_repo = PathBuf::from(&repo_path);
 
@@ -542,7 +547,7 @@ fn parse_orphan_worktrees(porcelain: &str) -> Vec<String> {
 
 /// Detect orphan worktrees: linked worktrees present on the filesystem but in detached HEAD
 /// state (i.e. their branch has been deleted). Returns a list of worktree directory paths.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn detect_orphan_worktrees(repo_path: String) -> Result<Vec<String>, String> {
     let base_repo = PathBuf::from(&repo_path);
 
@@ -558,6 +563,7 @@ pub(crate) fn detect_orphan_worktrees(repo_path: String) -> Result<Vec<String>, 
 ///
 /// Safety: `worktree_path` is validated against the repo's actual worktree list to prevent
 /// arbitrary directory deletion via a crafted path.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn remove_orphan_worktree(
     state: State<'_, Arc<AppState>>,
@@ -612,19 +618,19 @@ pub(crate) fn validate_worktree_path(repo_path: &str, worktree_path: &str) -> Re
 }
 
 /// Generate a worktree name (Story 063)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn generate_worktree_name_cmd(existing_names: Vec<String>) -> String {
     generate_worktree_name(&existing_names)
 }
 
 /// Generate a hybrid clone branch name: `{sanitized_source}--{random_name}`
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn generate_clone_branch_name_cmd(source_branch: String, existing_names: Vec<String>) -> String {
     generate_clone_branch_name(&source_branch, &existing_names)
 }
 
 /// List local branch names for a repository (excludes HEAD and remote-only refs)
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn list_local_branches(repo_path: String) -> Result<Vec<String>, String> {
     let out = git_cmd(Path::new(&repo_path))
         .args(["branch", "--format=%(refname:short)"])
@@ -726,7 +732,7 @@ pub(crate) struct BaseRefOption {
 /// Returns structured refs: default branch first (flagged), then local branches,
 /// then remote tracking branches. Filters out origin/HEAD and deduplicates
 /// where a local branch has the same name as its remote tracking branch.
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn list_base_ref_options(repo_path: String) -> Result<Vec<BaseRefOption>, String> {
     let default_branch = get_remote_default_branch(&repo_path)?;
     let repo = Path::new(&repo_path);
@@ -807,6 +813,7 @@ pub(crate) struct SwitchBranchResult {
 /// When `stash` is true, performs `git stash push` before checkout and
 /// does NOT auto-pop (the user can pop manually).
 /// When `force` is true, passes `--force` to discard uncommitted changes.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn switch_branch(
     state: State<'_, Arc<AppState>>,
@@ -879,6 +886,7 @@ pub(crate) fn switch_branch(
 
 /// Create a local branch tracking a remote branch and switch to it.
 /// Equivalent to `git checkout -b <branch> origin/<branch>`.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn checkout_remote_branch(
     state: State<'_, Arc<AppState>>,
@@ -912,6 +920,7 @@ pub(crate) struct MergeArchiveResult {
 ///
 /// Called after `merge_and_archive_worktree` returns `action: "pending"` (ask mode).
 /// The merge has already succeeded; this only handles the worktree cleanup.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn finalize_merged_worktree(
     state: State<'_, Arc<AppState>>,
@@ -950,6 +959,7 @@ pub(crate) fn finalize_merged_worktree(
 /// 1. `git checkout <target_branch>` (in the base repo)
 /// 2. `git merge <source_branch>` (in the base repo)
 /// 3. Based on `after_merge`: archive (move dir) or delete (remove worktree + branch)
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn merge_and_archive_worktree(
     state: State<'_, Arc<AppState>>,
@@ -1095,7 +1105,7 @@ fn run_script_in_dir(script: &str, cwd: &Path) -> Result<(), String> {
 ///
 /// Used to execute setup/run scripts after worktree creation.
 /// The script is passed to `sh -c` (Unix) or `cmd /C` (Windows).
-#[tauri::command]
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub(crate) fn run_setup_script(script: String, cwd: String) -> Result<serde_json::Value, String> {
     let cwd = crate::cli::expand_tilde(&cwd);
     let cwd_path = Path::new(&cwd);


### PR DESCRIPTION
## Summary

- Extract a standalone headless binary (`tuicommander-remote`) from the Tauri desktop app using Cargo feature flags
- `desktop` is the default feature; `--no-default-features` builds the headless daemon
- Headless binary serves the full HTTP/MCP API on a TCP port without any Tauri/WebView dependency
- 20MB stripped release binary

## What changed

- **Cargo.toml**: `desktop` feature gates `tauri`, window plugins, dictation, etc. as optional deps
- **`#[cfg(feature = "desktop")]`** on all Tauri-only modules (dictation, menu, panel_window, global_hotkey, updater, etc.)
- **`#[cfg_attr(feature = "desktop", tauri::command)]`** on 80+ command functions — keeps them callable from both IPC and HTTP
- **`AppState::new()` constructor** replaces ~80-line inline construction, used by both `run()` and tests
- **`wire_event_bus()`** for post-Arc setup (mcp_upstream_registry, oauth, tools_changed)
- **`run_headless(port)`** public entry point: loads config, spawns background tasks, starts HTTP server with graceful shutdown
- **`src/bin/tuicommander_remote.rs`**: minimal binary that reads `TUIC_PORT` env and calls `run_headless()`
- **PTY reader threads**: removed `AppHandle` threading, use `tokio::runtime::Handle::current()` instead of `tauri::async_runtime::handle()`
- **Event delivery**: `event_bus` (broadcast channel) is primary; `AppHandle.emit()` is desktop-only optimization behind `#[cfg]`

## Security hardening (review fixes)

- Loopback auth bypass disabled in headless mode (`#[cfg(feature = "desktop")]`)
- `lan_auth_bypass` forced off in headless with warning log
- Graceful shutdown via SIGINT/SIGTERM (`tokio::select!` + `ctrl_c`)
- Invalid `TUIC_PORT` warns instead of silently using default
- Port override from config is logged

## Test plan

- [x] `cargo check` passes (desktop)
- [x] `cargo check --no-default-features` passes (headless)
- [x] `cargo clippy` clean for both configurations
- [x] 2832 tests pass (desktop) — 2 pre-existing git worktree failures
- [x] 2758 tests pass (headless)
- [x] Headless binary starts, serves HTTP, responds to health/sessions/repo endpoints
- [x] Loopback requests require auth in headless mode
- [x] SIGINT triggers clean shutdown with exit code 0
- [x] Invalid TUIC_PORT prints warning
- [x] Release binary under 25MB target (20MB stripped)