### PR TITLE
fix(shell): ensure zsh compinit runs when ZDOTDIR trick skips it

### DIFF
--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -55,10 +55,6 @@ if [[ -n "$TUIC_SESSION" ]]; then
     esac
   }
 fi
-# Ensure zsh completion is active (ZDOTDIR trick + edge cases can skip system compinit)
-if [[ -o interactive ]] && ! type compdef >/dev/null 2>&1; then
-  autoload -Uz compinit && compinit
-fi
 "#;
 
 /// Bash shell integration script.
@@ -233,11 +229,19 @@ fn inject_zsh(base: &Path, cmd: &mut portable_pty::CommandBuilder) {
 
     // Passthrough wrappers for other dotfiles (so user config still loads)
     for dotfile in ZSH_DOTFILES {
-        let wrapper = format!(
+        let mut wrapper = format!(
             "# TUIC passthrough — load real {dotfile}\n\
              [[ -f \"${{TUIC_ORIGINAL_ZDOTDIR:-$HOME}}/{dotfile}\" ]] && \
              source \"${{TUIC_ORIGINAL_ZDOTDIR:-$HOME}}/{dotfile}\"\n"
         );
+        if dotfile == &".zshrc" {
+            wrapper.push_str(
+                "# Ensure completion is active (ZDOTDIR trick can skip system compinit)\n\
+                 if [[ -o interactive ]] && ! type compdef >/dev/null 2>&1; then\n\
+                 \x20 autoload -Uz compinit && compinit -C\n\
+                 fi\n",
+            );
+        }
         write_if_changed(&zdotdir.join(dotfile), &wrapper);
     }
 

--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -55,6 +55,10 @@ if [[ -n "$TUIC_SESSION" ]]; then
     esac
   }
 fi
+# Ensure zsh completion is active (ZDOTDIR trick + edge cases can skip system compinit)
+if [[ -o interactive ]] && ! type compdef >/dev/null 2>&1; then
+  autoload -Uz compinit && compinit
+fi
 "#;
 
 /// Bash shell integration script.


### PR DESCRIPTION
## Problem

Tab autocomplete stopped working inside TUICommander terminals for some zsh users.

The root cause is not in TUICommander's input pipeline — `\t` (0x09) is correctly forwarded to the PTY. The problem is in zsh's completion system not being initialized.

TUICommander uses a ZDOTDIR trick to inject OSC 133 shell integration hooks: it temporarily overrides `ZDOTDIR` to a wrapper directory, sources the integration script from `.zshenv`, then restores the original `ZDOTDIR` and sources the user's real dotfiles. In certain setups (conditional configs, Oh-My-Zsh, disordered `fpath`, system `/etc/zshrc` guards), this indirection can cause `compinit` to never run — leaving zsh with no completion system active.

## Fix

Added a guard to the zsh integration script (`ZSH_INTEGRATION` in `shell_integration.rs`):

```zsh
# Ensure zsh completion is active (ZDOTDIR trick + edge cases can skip system compinit)
if [[ -o interactive ]] && ! type compdef >/dev/null 2>&1; then
  autoload -Uz compinit && compinit
fi
```

- Only runs in interactive shells (no impact on scripts/subshells)
- `type compdef` check prevents double-init if user's `.zshrc` already called `compinit`
- Safe with Oh-My-Zsh, Prezto, and manual setups

## Tests

No unit tests added. The `ZSH_INTEGRATION` constant is a shell script string — its behavior can only be verified by running it in a real zsh process. The fix was verified manually: opened a new terminal in TUICommander after rebuilding, `ls /` + Tab autocompleted correctly.

A future improvement could be an integration test that spawns a zsh subprocess with the integration script sourced and asserts `compdef` is defined. Adding that is out of scope for this fix.

## Checklist

- [x] `cargo clippy` — no warnings
- [x] `cargo test` — passes
- [x] Manual test — tab autocomplete works in new terminals after rebuild