### PR TITLE
refactor(terminals): extract nextDefaultName() to eliminate duplication

### DIFF
--- a/src/__tests__/stores/terminals.test.ts
+++ b/src/__tests__/stores/terminals.test.ts
@@ -565,4 +565,21 @@ describe("terminalsStore", () => {
 			});
 		});
 	});
+
+	describe("nextDefaultName()", () => {
+		it("returns Terminal 1 when store is empty", () => {
+			testInScope(() => {
+				expect(store.nextDefaultName()).toBe("Terminal 1");
+			});
+		});
+
+		it("increments with each added terminal", () => {
+			testInScope(() => {
+				store.add(makeTerminal({ name: "T1" }));
+				expect(store.nextDefaultName()).toBe("Terminal 2");
+				store.add(makeTerminal({ name: "T2" }));
+				expect(store.nextDefaultName()).toBe("Terminal 3");
+			});
+		});
+	});
 });

--- a/src/components/PluginPanel/PluginPanel.tsx
+++ b/src/components/PluginPanel/PluginPanel.tsx
@@ -244,11 +244,10 @@ export const PluginPanel: Component<PluginPanelProps> = (props) => {
 					appLogger.warn("plugin", `tuic:terminal repo not in repo list: ${repoPath}`);
 					return;
 				}
-				const count = terminalsStore.getCount();
 				const id = terminalsStore.add({
 					sessionId: null,
 					fontSize: settingsStore.state.defaultFontSize,
-					name: `Terminal ${count + 1}`,
+					name: terminalsStore.nextDefaultName(),
 					cwd: repoPath,
 					awaitingInput: null,
 				});

--- a/src/hooks/useAppInit.ts
+++ b/src/hooks/useAppInit.ts
@@ -493,7 +493,7 @@ export async function initApp(deps: AppInitDeps) {
 			const id = terminalsStore.add({
 				sessionId: session.session_id,
 				fontSize: deps.getDefaultFontSize(),
-				name: session.display_name || `Terminal ${terminalsStore.getCount() + 1}`,
+				name: session.display_name || terminalsStore.nextDefaultName(),
 				cwd: session.cwd,
 				awaitingInput: null,
 			});

--- a/src/hooks/useTerminalLifecycle.ts
+++ b/src/hooks/useTerminalLifecycle.ts
@@ -74,11 +74,10 @@ export function useTerminalLifecycle(deps: TerminalLifecycleDeps) {
 		}
 
 		const activeTerminal = terminalsStore.getActive();
-		const count = terminalsStore.getCount();
 		const id = terminalsStore.add({
 			sessionId: null,
 			fontSize: activeTerminal?.fontSize ?? deps.getDefaultFontSize(),
-			name: `Terminal ${count + 1}`,
+			name: terminalsStore.nextDefaultName(),
 			cwd: activeTerminal?.cwd ?? repositoriesStore.state.activeRepoPath ?? null,
 			awaitingInput: null,
 		});

--- a/src/stores/terminals.ts
+++ b/src/stores/terminals.ts
@@ -603,6 +603,11 @@ function createTerminalsStore() {
 			return Object.keys(state.terminals).length;
 		},
 
+		/** Default name for the next terminal tab */
+		nextDefaultName(): string {
+			return `Terminal ${Object.keys(state.terminals).length + 1}`;
+		},
+
 		/** Debounced busy: true while shellState is "busy" and for 2s after it transitions to idle */
 		isBusy(id: string): boolean {
 			return state.debouncedBusy[id] ?? false;


### PR DESCRIPTION
## Summary

Three callsites computed the default terminal tab name inline by calling `terminalsStore.getCount()` directly and building the string themselves:

- `useTerminalLifecycle.ts` — generic "New Terminal" shortcut
- `PluginPanel.tsx` — `tuic:terminal` plugin command
- `useAppInit.ts` — session restore path

All three produced the identical `Terminal ${count + 1}` string with no shared abstraction. This adds `nextDefaultName()` to the terminals store so the logic lives in one place. Callers now simply call `terminalsStore.nextDefaultName()`.

No behaviour change — pure refactor.

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npx vitest run` passes (2 new unit tests for `nextDefaultName()`)

**New tests (`terminals.test.ts`):**
- Returns `"Terminal 1"` when the store is empty
- Returns `"Terminal N+1"` after N terminals have been added

🤖 Generated with [Claude Code](https://claude.com/claude-code)