### PR TITLE
fix(git): inject enriched PATH so git hooks can find pnpm/node

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -129,6 +129,21 @@ pub(crate) fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+/// Return a PATH string that prepends extra bin dirs to the current PATH.
+///
+/// Used to enrich subprocess environments so git hooks and other child
+/// processes can find tools (pnpm, node, etc.) that desktop-launched apps
+/// don't have on PATH.
+pub(crate) fn enriched_path() -> String {
+    let current = std::env::var("PATH").unwrap_or_default();
+    let extra = extra_bin_dirs().join(":");
+    if current.is_empty() {
+        extra
+    } else {
+        format!("{extra}:{current}")
+    }
+}
+
 /// Check if a CLI tool exists on PATH or in well-known directories.
 pub(crate) fn has_cli(name: &str) -> bool {
     let checker = if cfg!(target_os = "windows") {

--- a/src-tauri/src/git_cli.rs
+++ b/src-tauri/src/git_cli.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::cli::resolve_cli;
+use crate::cli::{enriched_path, resolve_cli};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -192,6 +192,7 @@ pub(crate) fn git_cmd(cwd: &Path) -> GitCmd {
     let mut cmd = Command::new(resolve_cli("git"));
     cmd.current_dir(cwd);
     cmd.env("GIT_TERMINAL_PROMPT", "0");
+    cmd.env("PATH", enriched_path());
     cmd.arg("--no-optional-locks");
     crate::cli::apply_no_window(&mut cmd);
     GitCmd {


### PR DESCRIPTION
## Summary

- Desktop-launched Tauri apps get a minimal PATH — no Homebrew, no version-manager shims
- `git worktree add` fires `post-checkout` hooks (husky, etc.) in a subprocess that inherits this minimal PATH
- `pnpm`/`node` not found → hook exits 127 → git reports "exited with code 127"

## Fix

- Added `enriched_path()` to `cli.rs`: prepends `extra_bin_dirs()` entries (Homebrew, cargo, etc.) to `$PATH`
- `git_cmd` now calls `cmd.env("PATH", enriched_path())` so every git subprocess — including hook scripts — sees the enriched PATH

## Test plan

- [ ] Create a worktree from a repo that has a husky `post-checkout` hook calling `pnpm`
- [ ] Verify worktree creation succeeds without exit code 127
- [ ] Verify git operations still work normally in repos without hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)