### PR TITLE
fix(git): close terminals before removing orphan worktrees

### DIFF
--- a/src/__tests__/hooks/useGitOperations.test.ts
+++ b/src/__tests__/hooks/useGitOperations.test.ts
@@ -1874,6 +1874,24 @@ describe("useGitOperations", () => {
 			expect(mockSetStatusInfo).toHaveBeenCalledWith("Removed 1 orphaned worktree(s)");
 		});
 
+		it("closes terminals in orphan worktree before auto-removing (orphanCleanup=on)", async () => {
+			repoSettingsStore.getOrCreate("/repo", "Repo");
+			repoSettingsStore.update("/repo", { orphanCleanup: "on" });
+			mockRepo.detectOrphanWorktrees.mockResolvedValue(["/wt/detached-1"]);
+
+			const termInOrphan = terminalsStore.add(makeTerminal({ name: "In orphan", cwd: "/wt/detached-1/subdir" }));
+			const termElsewhere = terminalsStore.add(makeTerminal({ name: "Elsewhere", cwd: "/repo" }));
+
+			await gitOps.refreshAllBranchStats();
+
+			expect(mockCloseTerminal).toHaveBeenCalledWith(termInOrphan, true);
+			expect(mockCloseTerminal).not.toHaveBeenCalledWith(termElsewhere, true);
+			// closeTerminal called before the worktree is removed
+			const closeOrder = mockCloseTerminal.mock.invocationCallOrder[0];
+			const removeOrder = mockRepo.removeOrphanWorktree.mock.invocationCallOrder[0];
+			expect(closeOrder).toBeLessThan(removeOrder);
+		});
+
 		it("asks user before removing when orphanCleanup=ask and user confirms", async () => {
 			const confirmOrphanCleanup = vi.fn().mockResolvedValue(true);
 			const askGitOps = useGitOperations({
@@ -1893,6 +1911,32 @@ describe("useGitOperations", () => {
 
 			expect(confirmOrphanCleanup).toHaveBeenCalledWith(["/wt/detached-1"]);
 			expect(mockRepo.removeOrphanWorktree).toHaveBeenCalledWith("/repo", "/wt/detached-1");
+		});
+
+		it("closes terminals in orphan worktree before removing when user confirms (orphanCleanup=ask)", async () => {
+			const confirmOrphanCleanup = vi.fn().mockResolvedValue(true);
+			const askGitOps = useGitOperations({
+				repo: mockRepo,
+				pty: mockPty,
+				dialogs: { ...mockDialogs, confirmOrphanCleanup },
+				closeTerminal: mockCloseTerminal,
+				createNewTerminal: mockCreateNewTerminal,
+				setStatusInfo: mockSetStatusInfo,
+				getDefaultFontSize: () => 14,
+				getMaxTabNameLength: () => 25,
+			});
+			mockRepo.detectOrphanWorktrees.mockResolvedValue(["/wt/detached-1"]);
+
+			const termInOrphan = terminalsStore.add(makeTerminal({ name: "In orphan", cwd: "/wt/detached-1" }));
+			const termElsewhere = terminalsStore.add(makeTerminal({ name: "Elsewhere", cwd: "/other" }));
+
+			await askGitOps.refreshAllBranchStats();
+
+			expect(mockCloseTerminal).toHaveBeenCalledWith(termInOrphan, true);
+			expect(mockCloseTerminal).not.toHaveBeenCalledWith(termElsewhere, true);
+			const closeOrder = mockCloseTerminal.mock.invocationCallOrder[0];
+			const removeOrder = mockRepo.removeOrphanWorktree.mock.invocationCallOrder[0];
+			expect(closeOrder).toBeLessThan(removeOrder);
 		});
 
 		it("skips removal when orphanCleanup=ask and user cancels", async () => {

--- a/src/hooks/useGitOperations.ts
+++ b/src/hooks/useGitOperations.ts
@@ -413,10 +413,20 @@ export function useGitOperations(deps: GitOperationsDeps) {
 		}
 		if (orphanPaths.length === 0) return;
 
+		const closeTerminalsInWorktree = async (wtPath: string) => {
+			for (const termId of terminalsStore.getIds()) {
+				const terminal = terminalsStore.get(termId);
+				if (terminal?.cwd && (terminal.cwd === wtPath || terminal.cwd.startsWith(wtPath + "/"))) {
+					await deps.closeTerminal(termId, true);
+				}
+			}
+		};
+
 		if (orphanCleanup === "on") {
 			// Auto-remove silently
 			for (const wtPath of orphanPaths) {
 				try {
+					await closeTerminalsInWorktree(wtPath);
 					await deps.repo.removeOrphanWorktree(repoPath, wtPath);
 				} catch (err) {
 					appLogger.warn("git", `Failed to auto-remove orphan worktree ${wtPath}`, err);
@@ -439,6 +449,7 @@ export function useGitOperations(deps: GitOperationsDeps) {
 
 		for (const wtPath of orphanPaths) {
 			try {
+				await closeTerminalsInWorktree(wtPath);
 				await deps.repo.removeOrphanWorktree(repoPath, wtPath);
 			} catch (err) {
 				appLogger.warn("git", `Failed to remove orphan worktree ${wtPath}`, err);


### PR DESCRIPTION
## Summary

- Terminals running inside an orphaned worktree were kept alive when the worktree directory was deleted
- The PTY process detected its CWD was gone and wrote ANSI escape sequences that painted the entire terminal canvas solid magenta (`#FF00FF`), corrupting the UI
- Fix: close every terminal whose `cwd` is inside the orphan path before calling `removeOrphanWorktree`, matching the pattern `handleRemoveBranch` already uses for named worktrees
- Applied to both `orphanCleanup=on` (auto-remove) and `orphanCleanup=ask` (user-confirmed) paths

## Screenshot of issue
<img width="1470" height="1009" alt="Screenshot 2026-05-12 at 11 18 42" src="https://github.com/user-attachments/assets/1fdc3ae2-5071-4f64-8bf4-a11c86ea492e" />


## Test plan

- [x] `npx vitest run src/__tests__/hooks/useGitOperations.test.ts` — 120 tests pass (added 2 regression tests covering close-before-remove ordering for both cleanup modes)
- [x] `npx tsc --noEmit` — clean

**Manual repro (before fix):** add a repo with a linked worktree, delete the worktree directory externally, restart the app so it detects the orphan, click Remove in the dialog → terminal canvas turns solid magenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)