### PR TITLE
fix(deps): remove RUSTSEC-2023-0071 (rsa Marvin Attack) via direct p256 VAPID signing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -25,19 +25,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
-dependencies = [
- "cipher 0.5.1",
- "cpubits",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -47,21 +36,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "aes-keywrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
-dependencies = [
- "aes 0.9.0",
- "byteorder",
 ]
 
 [[package]]
@@ -266,12 +245,6 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -712,12 +685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binstring"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,17 +712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -796,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1084,18 +1040,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
-dependencies = [
- "crypto-common 0.2.1",
- "inout 0.2.2",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1171,17 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "coarsetime"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
-dependencies = [
- "libc",
- "wasix",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1470,12 +1405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpubits"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,15 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,12 +1547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-codecs"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
-
-[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,7 +1562,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1871,7 +1785,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -2031,16 +1945,6 @@ dependencies = [
  "aes-gcm",
  "hkdf",
  "sha2",
-]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ce99a9e19c84beb4cc35ece85374335ccc398240712114c85038319ed709bd"
-dependencies = [
- "ct-codecs",
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3097,30 +3001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-sha1-compact"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "hmac-sha512"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,15 +3093,6 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -3561,15 +3432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,46 +3608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt-simple"
-version = "0.12.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3991f54af4b009bb6efe01aa5a4fcce9ca52f3de7a104a3f6b6e2ad36c852c48"
-dependencies = [
- "anyhow",
- "binstring",
- "blake2b_simd",
- "coarsetime",
- "ct-codecs",
- "ed25519-compact",
- "hmac-sha1-compact",
- "hmac-sha256",
- "hmac-sha512",
- "k256",
- "p256",
- "p384",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "superboring",
- "thiserror 2.0.18",
- "zeroize",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
-]
-
-[[package]]
 name = "keepawake"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,9 +3685,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3953,12 +3772,6 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -4420,22 +4233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,33 +4250,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -4938,18 +4714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5267,17 +5031,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -6002,27 +5755,6 @@ dependencies = [
  "hound",
  "lewton",
  "symphonia",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -6810,12 +6542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6946,21 +6672,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "superboring"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8af9125d1ea290cf5c297b94d0e518c939bbe1f45ef130c19525dae7afba99"
-dependencies = [
- "aes-gcm",
- "aes-keywrap",
- "getrandom 0.2.17",
- "hmac-sha256",
- "hmac-sha512",
- "rand 0.8.5",
- "rsa",
-]
 
 [[package]]
 name = "swift-rs"
@@ -8227,9 +7938,11 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "p256",
  "parking_lot",
  "portable-pty",
  "rand 0.10.0",
+ "rand_core 0.6.4",
  "regex",
  "reqwest 0.13.2",
  "rodio",
@@ -8411,7 +8124,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -8608,15 +8321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasix"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
-dependencies = [
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8799,7 +8503,6 @@ dependencies = [
  "ece-native",
  "hkdf",
  "http",
- "jwt-simple",
  "p256",
  "serde",
  "sha2",
@@ -9944,7 +9647,7 @@ version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "bzip2",
  "constant_time_eq",
  "crc32fast",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,7 +141,9 @@ sha2 = "0.10"
 hkdf = "0.12"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 axum-server-dual-protocol = "0.7"
-web-push-native = "0.4"
+web-push-native = { version = "0.4", default-features = false, features = ["serialization"] }
+p256 = { version = "0.13", features = ["ecdsa"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 base64ct = { version = "1", features = ["alloc"] }
 anyhow = "1"
 oauth2 = "5"

--- a/src-tauri/src/push.rs
+++ b/src-tauri/src/push.rs
@@ -147,19 +147,12 @@ impl PushStore {
 /// Generate a new ES256 VAPID key pair for Web Push.
 /// Returns (private_key_base64url, public_key_base64url).
 pub(crate) fn generate_vapid_keys() -> Result<(String, String), String> {
-    use web_push_native::jwt_simple::algorithms::ES256KeyPair;
-    use web_push_native::p256::elliptic_curve::sec1::ToEncodedPoint;
+    use p256::ecdsa::SigningKey;
+    use rand_core::OsRng;
 
-    let kp = ES256KeyPair::generate();
-    let private_bytes = kp.to_bytes();
-    let private_b64 = Base64UrlUnpadded::encode_string(&private_bytes);
-
-    // ES256PublicKey::to_bytes() returns compressed (33 bytes); VAPID needs
-    // uncompressed (65 bytes). Re-parse via p256 crate and decompress.
-    let compressed = kp.public_key().to_bytes();
-    let p256_key = web_push_native::p256::PublicKey::from_sec1_bytes(&compressed)
-        .map_err(|e| format!("Failed to parse public key: {e}"))?;
-    let uncompressed = p256_key.to_encoded_point(false);
+    let signing_key = SigningKey::random(&mut OsRng);
+    let private_b64 = Base64UrlUnpadded::encode_string(signing_key.to_bytes().as_ref());
+    let uncompressed = signing_key.verifying_key().to_encoded_point(false);
     let public_b64 = Base64UrlUnpadded::encode_string(uncompressed.as_bytes());
 
     Ok((private_b64, public_b64))
@@ -175,7 +168,7 @@ pub(crate) async fn send_push_batch(
     body: &str,
     url: &str,
 ) -> Vec<String> {
-    use web_push_native::jwt_simple::algorithms::ES256KeyPair;
+    use p256::ecdsa::SigningKey;
 
     let mut stale_endpoints: Vec<String> = Vec::new();
 
@@ -196,7 +189,10 @@ pub(crate) async fn send_push_batch(
             return stale_endpoints;
         }
     };
-    let vapid_kp = match ES256KeyPair::from_bytes(&kp_bytes) {
+    let vapid_kp = match p256::SecretKey::from_slice(&kp_bytes)
+        .map(|sk| SigningKey::from(&sk))
+        .map_err(|e| e.to_string())
+    {
         Ok(kp) => kp,
         Err(e) => {
             tracing::error!(source = "push", "Failed to load VAPID key pair: {e}");
@@ -275,15 +271,56 @@ pub(crate) async fn send_push_batch(
     stale_endpoints
 }
 
+/// Build an RFC 8292 VAPID `Authorization` header value.
+/// JWT header+claims are ES256-signed with the P-256 key; signature is IEEE P1363 (r||s).
+fn build_vapid_authorization(
+    signing_key: &p256::ecdsa::SigningKey,
+    endpoint: &axum::http::Uri,
+    subject: &str,
+    valid_secs: u64,
+) -> Result<axum::http::HeaderValue, String> {
+    use p256::ecdsa::{signature::Signer, Signature};
+
+    let jwt_header = Base64UrlUnpadded::encode_string(br#"{"alg":"ES256","typ":"JWT"}"#);
+
+    let exp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        + valid_secs;
+    let audience = format!(
+        "{}://{}",
+        endpoint.scheme_str().ok_or("endpoint missing scheme")?,
+        endpoint.host().ok_or("endpoint missing host")?,
+    );
+    let claims_json = serde_json::to_string(&serde_json::json!({
+        "aud": audience,
+        "exp": exp,
+        "sub": subject,
+    }))
+    .map_err(|e| format!("VAPID claims serialization failed: {e}"))?;
+    let jwt_claims = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
+
+    let signing_input = format!("{jwt_header}.{jwt_claims}");
+    let sig: Signature = signing_key.sign(signing_input.as_bytes());
+    let sig_b64 = Base64UrlUnpadded::encode_string(&sig.to_bytes());
+    let jwt = format!("{signing_input}.{sig_b64}");
+
+    let public_b64 = Base64UrlUnpadded::encode_string(
+        signing_key.verifying_key().to_encoded_point(false).as_bytes(),
+    );
+
+    axum::http::HeaderValue::try_from(format!("vapid t={jwt}, k={public_b64}"))
+        .map_err(|e| format!("Invalid VAPID header value: {e}"))
+}
+
 /// Build a single push request for a subscription. Returns None if the subscription is invalid.
 fn build_push_request(
     sub: &PushSubscription,
-    vapid_kp: &web_push_native::jwt_simple::algorithms::ES256KeyPair,
+    vapid_signing_key: &p256::ecdsa::SigningKey,
     vapid_subject: &str,
     payload_bytes: &[u8],
 ) -> Option<(String, axum::http::Request<Vec<u8>>)> {
-    use web_push_native::p256;
-
     let p256dh_bytes = match Base64UrlUnpadded::decode_vec(&sub.keys.p256dh) {
         Ok(b) => b,
         Err(e) => {
@@ -322,11 +359,20 @@ fn build_push_request(
         arr.into()
     };
 
-    let builder = web_push_native::WebPushBuilder::new(endpoint, ua_public, ua_auth)
-        .with_vapid(vapid_kp, vapid_subject);
+    let auth_header = match build_vapid_authorization(vapid_signing_key, &endpoint, vapid_subject, 12 * 3600) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(source = "push", endpoint = %sub.endpoint, "VAPID signing failed: {e}");
+            return None;
+        }
+    };
 
+    let builder = web_push_native::WebPushBuilder::new(endpoint, ua_public, ua_auth);
     match builder.build(payload_bytes.to_vec()) {
-        Ok(request) => Some((sub.endpoint.clone(), request)),
+        Ok(mut request) => {
+            request.headers_mut().insert(axum::http::header::AUTHORIZATION, auth_header);
+            Some((sub.endpoint.clone(), request))
+        }
         Err(e) => {
             tracing::warn!(source = "push", "Failed to build push request: {e}");
             None
@@ -407,5 +453,71 @@ mod tests {
         assert!(validate_push_endpoint("https://169.254.169.254/metadata").is_err());
         assert!(validate_push_endpoint("http://fcm.googleapis.com/fcm/send/abc").is_err()); // http not https
         assert!(validate_push_endpoint("https://10.0.0.1/internal").is_err());
+    }
+
+    #[test]
+    fn generate_vapid_keys_produces_valid_p256_pair() {
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+        let (priv_b64, pub_b64) = generate_vapid_keys().unwrap();
+
+        // Private key: 32 bytes (P-256 scalar)
+        let priv_bytes = base64ct::Base64UrlUnpadded::decode_vec(&priv_b64).unwrap();
+        assert_eq!(priv_bytes.len(), 32, "private key must be 32 bytes");
+
+        // Public key: 65 bytes uncompressed (0x04 prefix + X + Y)
+        let pub_bytes = base64ct::Base64UrlUnpadded::decode_vec(&pub_b64).unwrap();
+        assert_eq!(pub_bytes.len(), 65, "public key must be 65 bytes uncompressed");
+        assert_eq!(pub_bytes[0], 0x04, "uncompressed point must start with 0x04");
+
+        // Key round-trip: private → load → same public key
+        let sk = p256::SecretKey::from_slice(&priv_bytes).unwrap();
+        let loaded_pub = sk.public_key().to_encoded_point(false);
+        assert_eq!(loaded_pub.as_bytes(), pub_bytes.as_slice());
+    }
+
+    #[test]
+    fn build_vapid_authorization_produces_valid_jwt_structure() {
+        use base64ct::Encoding;
+        use p256::ecdsa::SigningKey;
+        use rand_core::OsRng;
+
+        let signing_key = SigningKey::random(&mut OsRng);
+        let endpoint: axum::http::Uri = "https://fcm.googleapis.com/fcm/send/test".parse().unwrap();
+        let header_val =
+            build_vapid_authorization(&signing_key, &endpoint, "mailto:test@example.com", 3600)
+                .unwrap();
+
+        let header_str = header_val.to_str().unwrap();
+        assert!(header_str.starts_with("vapid t="), "must start with 'vapid t='");
+        assert!(header_str.contains(", k="), "must contain ', k=' separator");
+
+        // Extract and decode the JWT
+        let t_part = header_str
+            .split("vapid t=")
+            .nth(1)
+            .unwrap()
+            .split(", k=")
+            .next()
+            .unwrap();
+        let parts: Vec<&str> = t_part.split('.').collect();
+        assert_eq!(parts.len(), 3, "JWT must have 3 dot-separated parts");
+
+        // Header must declare ES256
+        let jwt_header_json = base64ct::Base64UrlUnpadded::decode_vec(parts[0]).unwrap();
+        let jwt_header: serde_json::Value = serde_json::from_slice(&jwt_header_json).unwrap();
+        assert_eq!(jwt_header["alg"], "ES256");
+        assert_eq!(jwt_header["typ"], "JWT");
+
+        // Claims must contain aud, exp, sub
+        let jwt_claims_json = base64ct::Base64UrlUnpadded::decode_vec(parts[1]).unwrap();
+        let jwt_claims: serde_json::Value = serde_json::from_slice(&jwt_claims_json).unwrap();
+        assert_eq!(jwt_claims["aud"], "https://fcm.googleapis.com");
+        assert!(jwt_claims["exp"].as_u64().unwrap() > 0);
+        assert_eq!(jwt_claims["sub"], "mailto:test@example.com");
+
+        // Signature must be 64 bytes (IEEE P1363 r||s)
+        let sig_bytes = base64ct::Base64UrlUnpadded::decode_vec(parts[2]).unwrap();
+        assert_eq!(sig_bytes.len(), 64, "ES256 signature must be 64 bytes (r||s)");
     }
 }


### PR DESCRIPTION
Closes #33 (partially — fixes the RUSTSEC-2023-0071 vulnerability; remaining warnings are GTK3/Tauri and not actionable).

## Summary

- **RUSTSEC-2023-0071** (rsa 0.9.10, Marvin Attack timing side-channel, severity 5.9): **eliminated** by removing the `rsa` → `superboring` → `jwt-simple` → `web-push-native` dependency chain
- Replace: disable `vapid` feature of `web-push-native`, implement RFC 8292 VAPID JWT signing directly with `p256::ecdsa::SigningKey` + `rand_core`
- The wire format is identical (ES256 JWT, same `{"alg":"ES256","typ":"JWT"}` header, same `aud`/`exp`/`sub` claims, same `vapid t=…, k=…` Authorization header) — **not a breaking change**, existing push subscriptions keep working
- **Remaining warnings** (`atk`, `atk-sys`, `gdk`, `gdk-sys`, `fxhash`): all GTK3 bindings from Tauri on Linux — not fixable without a Tauri GTK4 upgrade

## Dep tree before → after

```
Before: rsa 0.9.10 ← superboring 0.1.8 ← jwt-simple 0.12.14 ← web-push-native
After:  p256 0.13 (ecdsa feature) + rand_core 0.6 (both already transitive deps, now direct)
```

Net change: −28 crates from the dep tree.

## Test plan

- [x] `cargo test` — 3087 passed, 10 ignored (added 2 new tests: `generate_vapid_keys_produces_valid_p256_pair` and `build_vapid_authorization_produces_valid_jwt_structure`)
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] `cargo audit` — RUSTSEC-2023-0071 no longer reported; only unmaintained GTK3 warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)