### PR TITLE
fix(worktree): honour Keep-worktree intent in post-merge cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuicommander",
-  "version": "1.2.2-nightly",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuicommander",
-      "version": "1.2.2-nightly",
+      "version": "1.2.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.2",
         "@codemirror/commands": "^6.10.3",
@@ -413,9 +413,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -433,9 +430,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -453,9 +447,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -473,9 +464,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1803,9 +1791,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1821,9 +1806,6 @@
       "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1841,9 +1823,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1859,9 +1838,6 @@
       "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1879,9 +1855,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1897,9 +1870,6 @@
       "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2067,9 +2037,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2082,9 +2049,6 @@
       "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2099,9 +2063,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2114,9 +2075,6 @@
       "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2131,9 +2089,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,9 +2101,6 @@
       "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2163,9 +2115,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2178,9 +2127,6 @@
       "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2195,9 +2141,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,9 +2153,6 @@
       "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2227,9 +2167,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,9 +2180,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2258,9 +2192,6 @@
       "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2500,9 +2431,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2520,9 +2448,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2540,9 +2465,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2560,9 +2482,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2580,9 +2499,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5099,9 +5015,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5121,9 +5034,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5145,9 +5055,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5167,9 +5074,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1797,6 +1797,47 @@ branch refs/heads/feat
         assert!(!wt.path.exists(), "Worktree directory should be gone");
     }
 
+    /// Regression test for the "Keep worktree" bug.
+    ///
+    /// PostMergeCleanupDialog lets the user uncheck the "Archive/Delete worktree"
+    /// step (intent: keep the worktree on disk) while leaving the "Delete local
+    /// branch" step checked. The frontend then invokes `delete_local_branch`,
+    /// which routes here through `delete_local_branch_impl`. Today this function
+    /// has no opt-out: when a linked worktree exists it unconditionally calls
+    /// `remove_worktree_by_branch`, so the worktree directory is destroyed
+    /// regardless of the user's intent.
+    ///
+    /// Expected behaviour: a code path that deletes the branch ref while
+    /// preserving the worktree directory on disk. This test fails today and
+    /// guards the fix.
+    #[test]
+    fn delete_local_branch_should_preserve_worktree_when_user_keeps_it() {
+        let repo = setup_test_repo();
+        let repo_path = repo.path().to_string_lossy().to_string();
+        let worktrees_dir = repo.path().join("worktrees");
+
+        let config = WorktreeConfig {
+            task_name: "wt-keep".to_string(),
+            base_repo: repo_path.clone(),
+            branch: None,
+            create_branch: false,
+        };
+        let wt = create_worktree_internal(&worktrees_dir, &config, None)
+            .expect("Failed to create worktree");
+        assert!(wt.path.exists(), "precondition: worktree should exist");
+
+        // Simulates PostMergeCleanupDialog flow with the worktree step
+        // unchecked but delete-local checked. The current API offers no way
+        // to express "keep worktree", so the cascade runs unconditionally.
+        let _ = delete_local_branch_impl(&repo_path, &wt.name);
+
+        assert!(
+            wt.path.exists(),
+            "BUG: linked worktree was deleted by the delete_local_branch cascade \
+             even though the user chose to keep it in the cleanup dialog"
+        );
+    }
+
     #[test]
     fn check_worktree_dirty_clean_worktree() {
         let repo = setup_test_repo();

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -484,11 +484,22 @@ pub(crate) fn check_worktree_dirty(repo_path: String, branch_name: String) -> Re
     Ok(!status_out.stdout.trim().is_empty())
 }
 
-/// Delete a local branch, removing its worktree first if one exists.
+/// Delete a local branch.
+///
+/// When the branch has a linked worktree, behaviour depends on `keep_worktree`:
+/// - `false` (default): remove the worktree directory together with the branch
+///   ref via `remove_worktree_by_branch`.
+/// - `true`: detach the worktree HEAD (so the branch ref is no longer checked
+///   out anywhere), then delete the branch ref with `git branch -d`. The
+///   worktree directory and its files are preserved.
 ///
 /// Safety: refuses to delete the repository's default branch.
 /// Uses `git branch -d` (safe delete) which fails if the branch has unmerged commits.
-pub(crate) fn delete_local_branch_impl(repo_path: &str, branch_name: &str) -> Result<(), String> {
+pub(crate) fn delete_local_branch_impl(
+    repo_path: &str,
+    branch_name: &str,
+    keep_worktree: bool,
+) -> Result<(), String> {
     // Refuse to delete the default branch
     let default_branch =
         get_remote_default_branch(repo_path).unwrap_or_else(|_| "main".to_string());
@@ -498,36 +509,61 @@ pub(crate) fn delete_local_branch_impl(repo_path: &str, branch_name: &str) -> Re
 
     let base_repo = PathBuf::from(repo_path);
 
-    // Check if branch has a linked worktree
-    let has_worktree = git_cmd(&base_repo)
+    // Resolve linked-worktree path for this branch, if any
+    let worktree_path = git_cmd(&base_repo)
         .args(["worktree", "list", "--porcelain"])
         .run_silent()
-        .map(|o| find_worktree_path_for_branch(&o.stdout, branch_name).is_some())
-        .unwrap_or(false);
+        .and_then(|o| find_worktree_path_for_branch(&o.stdout, branch_name));
 
-    if has_worktree {
-        // Remove worktree + branch in one go
-        remove_worktree_by_branch(repo_path, branch_name, true, None)?;
-    } else {
-        // Just delete the branch ref
-        git_cmd(&base_repo)
-            .args(["branch", "-d", branch_name])
-            .run()
-            .map_err(|e| format!("git branch -d {branch_name} failed: {e}"))?;
+    match (worktree_path, keep_worktree) {
+        (Some(wt_path), true) => {
+            // Detach the worktree HEAD so `git branch -d` will accept the
+            // branch as deletable while leaving the worktree files on disk.
+            git_cmd(&wt_path)
+                .args(["checkout", "--detach"])
+                .run()
+                .map_err(|e| {
+                    format!(
+                        "git checkout --detach in worktree {} failed: {e}",
+                        wt_path.display()
+                    )
+                })?;
+            git_cmd(&base_repo)
+                .args(["branch", "-d", branch_name])
+                .run()
+                .map_err(|e| format!("git branch -d {branch_name} failed: {e}"))?;
+        }
+        (Some(_), false) => {
+            // Remove worktree + branch in one go
+            remove_worktree_by_branch(repo_path, branch_name, true, None)?;
+        }
+        (None, _) => {
+            // Bare branch — no worktree to consider
+            git_cmd(&base_repo)
+                .args(["branch", "-d", branch_name])
+                .run()
+                .map_err(|e| format!("git branch -d {branch_name} failed: {e}"))?;
+        }
     }
 
     Ok(())
 }
 
-/// Tauri command: delete a local branch (and its worktree if linked).
+/// Tauri command: delete a local branch.
+///
+/// `keep_worktree` (optional, default `false`): when `true`, preserves the
+/// linked worktree directory by detaching its HEAD before removing the branch
+/// ref. Used by the post-merge cleanup dialog when the user unchecks the
+/// "Archive/Delete worktree" step.
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub(crate) fn delete_local_branch(
     state: State<'_, Arc<AppState>>,
     repo_path: String,
     branch_name: String,
+    keep_worktree: Option<bool>,
 ) -> Result<(), String> {
-    delete_local_branch_impl(&repo_path, &branch_name)?;
+    delete_local_branch_impl(&repo_path, &branch_name, keep_worktree.unwrap_or(false))?;
     state.invalidate_repo_caches(&repo_path);
     Ok(())
 }
@@ -1739,7 +1775,7 @@ branch refs/heads/feat
         assert!(branches.contains(&"feat-to-delete".to_string()));
 
         // Delete it
-        let result = delete_local_branch_impl(&repo_path, "feat-to-delete");
+        let result = delete_local_branch_impl(&repo_path, "feat-to-delete", false);
         assert!(
             result.is_ok(),
             "delete_local_branch_impl failed: {:?}",
@@ -1757,7 +1793,7 @@ branch refs/heads/feat
         let repo_path = repo.path().to_string_lossy().to_string();
 
         let default_branch = get_remote_default_branch(&repo_path).unwrap();
-        let result = delete_local_branch_impl(&repo_path, &default_branch);
+        let result = delete_local_branch_impl(&repo_path, &default_branch, false);
         assert!(result.is_err());
         assert!(
             result
@@ -1785,8 +1821,8 @@ branch refs/heads/feat
         // Verify worktree exists
         assert!(wt.path.exists());
 
-        // Delete via delete_local_branch_impl
-        let result = delete_local_branch_impl(&repo_path, &wt.name);
+        // Delete via delete_local_branch_impl (default cascade: keep_worktree = false)
+        let result = delete_local_branch_impl(&repo_path, &wt.name, false);
         assert!(
             result.is_ok(),
             "delete_local_branch_impl failed: {:?}",
@@ -1801,15 +1837,9 @@ branch refs/heads/feat
     ///
     /// PostMergeCleanupDialog lets the user uncheck the "Archive/Delete worktree"
     /// step (intent: keep the worktree on disk) while leaving the "Delete local
-    /// branch" step checked. The frontend then invokes `delete_local_branch`,
-    /// which routes here through `delete_local_branch_impl`. Today this function
-    /// has no opt-out: when a linked worktree exists it unconditionally calls
-    /// `remove_worktree_by_branch`, so the worktree directory is destroyed
-    /// regardless of the user's intent.
-    ///
-    /// Expected behaviour: a code path that deletes the branch ref while
-    /// preserving the worktree directory on disk. This test fails today and
-    /// guards the fix.
+    /// branch" step checked. With `keep_worktree = true`, `delete_local_branch_impl`
+    /// must detach the worktree HEAD and remove only the branch ref, leaving the
+    /// worktree directory and its files intact.
     #[test]
     fn delete_local_branch_should_preserve_worktree_when_user_keeps_it() {
         let repo = setup_test_repo();
@@ -1827,14 +1857,25 @@ branch refs/heads/feat
         assert!(wt.path.exists(), "precondition: worktree should exist");
 
         // Simulates PostMergeCleanupDialog flow with the worktree step
-        // unchecked but delete-local checked. The current API offers no way
-        // to express "keep worktree", so the cascade runs unconditionally.
-        let _ = delete_local_branch_impl(&repo_path, &wt.name);
+        // unchecked but delete-local checked. `keep_worktree = true` must
+        // detach the worktree HEAD and remove only the branch ref.
+        let result = delete_local_branch_impl(&repo_path, &wt.name, true);
+        assert!(
+            result.is_ok(),
+            "delete_local_branch_impl with keep_worktree=true failed: {:?}",
+            result
+        );
 
         assert!(
             wt.path.exists(),
-            "BUG: linked worktree was deleted by the delete_local_branch cascade \
-             even though the user chose to keep it in the cleanup dialog"
+            "Worktree directory was deleted despite keep_worktree=true"
+        );
+
+        // Branch ref must be gone
+        let branches = list_local_branches(repo_path).unwrap();
+        assert!(
+            !branches.contains(&wt.name),
+            "Branch ref should have been deleted"
         );
     }
 

--- a/src/__tests__/hooks/usePostMergeCleanup.test.ts
+++ b/src/__tests__/hooks/usePostMergeCleanup.test.ts
@@ -140,6 +140,7 @@ describe("executeCleanup", () => {
 		expect(mockInvoke).toHaveBeenCalledWith("delete_local_branch", {
 			repoPath: "/repo",
 			branchName: "feature/login",
+			keepWorktree: false,
 		});
 		// closeTerminals was called before delete
 		const closeOrder = closeTerminals.mock.invocationCallOrder[0];
@@ -345,25 +346,13 @@ describe("executeCleanup", () => {
 	/**
 	 * Regression test for the "Keep worktree" bug.
 	 *
-	 * PostMergeCleanupDialog lets the user UNCHECK the "Archive/Delete worktree"
-	 * step (intent: keep the worktree on disk) while leaving the "Delete local
-	 * branch" step CHECKED. Today executeCleanup invokes
-	 * `delete_local_branch` with only `{ repoPath, branchName }` — no signal
-	 * for the Rust side that the worktree must be preserved. The Rust impl
-	 * (`delete_local_branch_impl` in `src-tauri/src/worktree.rs`) then
-	 * unconditionally calls `remove_worktree_by_branch`, destroying the
-	 * worktree the user explicitly kept.
-	 *
-	 * Acceptable fixes:
-	 *   (a) Skip delete-local when worktree step is unchecked (and warn the
-	 *       user — git refuses `branch -d` on a branch checked out in a
-	 *       linked worktree anyway).
-	 *   (b) Pass `keepWorktree: true` so the Rust side skips the cascade.
-	 *
-	 * Either way, the current invocation contract is wrong. This test fails
-	 * today and guards the fix.
+	 * When the user unchecks the "Archive/Delete worktree" step in
+	 * PostMergeCleanupDialog while leaving "Delete local branch" checked,
+	 * executeCleanup must pass `keepWorktree: true` to the
+	 * `delete_local_branch` command so the Rust side skips its cascade and
+	 * preserves the worktree directory.
 	 */
-	it("does not destroy the kept worktree when user unchecks the worktree step", async () => {
+	it("passes keepWorktree: true when user unchecks the worktree step", async () => {
 		const config = makeConfig({
 			steps: [
 				{ id: "worktree", checked: false }, // user KEEPS the worktree
@@ -376,19 +365,11 @@ describe("executeCleanup", () => {
 		});
 		await executeCleanup(config);
 
-		const deleteLocalCall = mockInvoke.mock.calls.find(
-			(c: unknown[]) => c[0] === "delete_local_branch",
-		);
-
-		// Either delete-local is skipped entirely (option a), or it must
-		// carry a keep-worktree signal so the Rust cascade is bypassed
-		// (option b). Today neither is true: delete-local fires with no flag.
-		if (deleteLocalCall === undefined) {
-			// Option (a) — accept the skip and bail out.
-			return;
-		}
-		const args = deleteLocalCall[1] as Record<string, unknown> | undefined;
-		expect(args?.keepWorktree).toBe(true);
+		expect(mockInvoke).toHaveBeenCalledWith("delete_local_branch", {
+			repoPath: "/repo",
+			branchName: "feature/login",
+			keepWorktree: true,
+		});
 	});
 
 	it("calls bumpRevision at the end even without local delete", async () => {

--- a/src/__tests__/hooks/usePostMergeCleanup.test.ts
+++ b/src/__tests__/hooks/usePostMergeCleanup.test.ts
@@ -342,6 +342,55 @@ describe("executeCleanup", () => {
 		expect(mockInvoke).not.toHaveBeenCalledWith("finalize_merged_worktree", expect.anything());
 	});
 
+	/**
+	 * Regression test for the "Keep worktree" bug.
+	 *
+	 * PostMergeCleanupDialog lets the user UNCHECK the "Archive/Delete worktree"
+	 * step (intent: keep the worktree on disk) while leaving the "Delete local
+	 * branch" step CHECKED. Today executeCleanup invokes
+	 * `delete_local_branch` with only `{ repoPath, branchName }` — no signal
+	 * for the Rust side that the worktree must be preserved. The Rust impl
+	 * (`delete_local_branch_impl` in `src-tauri/src/worktree.rs`) then
+	 * unconditionally calls `remove_worktree_by_branch`, destroying the
+	 * worktree the user explicitly kept.
+	 *
+	 * Acceptable fixes:
+	 *   (a) Skip delete-local when worktree step is unchecked (and warn the
+	 *       user — git refuses `branch -d` on a branch checked out in a
+	 *       linked worktree anyway).
+	 *   (b) Pass `keepWorktree: true` so the Rust side skips the cascade.
+	 *
+	 * Either way, the current invocation contract is wrong. This test fails
+	 * today and guards the fix.
+	 */
+	it("does not destroy the kept worktree when user unchecks the worktree step", async () => {
+		const config = makeConfig({
+			steps: [
+				{ id: "worktree", checked: false }, // user KEEPS the worktree
+				{ id: "switch", checked: false },
+				{ id: "pull", checked: false },
+				{ id: "delete-local", checked: true }, // still wants branch gone
+				{ id: "delete-remote", checked: false },
+			],
+			worktreeAction: "archive",
+		});
+		await executeCleanup(config);
+
+		const deleteLocalCall = mockInvoke.mock.calls.find(
+			(c: unknown[]) => c[0] === "delete_local_branch",
+		);
+
+		// Either delete-local is skipped entirely (option a), or it must
+		// carry a keep-worktree signal so the Rust cascade is bypassed
+		// (option b). Today neither is true: delete-local fires with no flag.
+		if (deleteLocalCall === undefined) {
+			// Option (a) — accept the skip and bail out.
+			return;
+		}
+		const args = deleteLocalCall[1] as Record<string, unknown> | undefined;
+		expect(args?.keepWorktree).toBe(true);
+	});
+
 	it("calls bumpRevision at the end even without local delete", async () => {
 		const config = makeConfig({
 			steps: [

--- a/src/hooks/usePostMergeCleanup.ts
+++ b/src/hooks/usePostMergeCleanup.ts
@@ -23,6 +23,14 @@ export async function executeCleanup(config: CleanupConfig): Promise<void> {
 	let didDeleteLocal = false;
 	let hadError = false;
 
+	// When the "worktree" step is present in the list but unchecked, the user
+	// explicitly chose to keep the worktree on disk. The "delete-local" step
+	// must communicate that to the Rust side, otherwise `delete_local_branch`
+	// will cascade through `remove_worktree_by_branch` and destroy the
+	// worktree directory regardless of the user's intent.
+	const worktreeStep = steps.find((s) => s.id === "worktree");
+	const keepWorktree = worktreeStep !== undefined && !worktreeStep.checked;
+
 	for (const step of steps) {
 		if (!step.checked) continue;
 		if (hadError) break;
@@ -69,6 +77,7 @@ export async function executeCleanup(config: CleanupConfig): Promise<void> {
 						await invoke("delete_local_branch", {
 							repoPath,
 							branchName,
+							keepWorktree,
 						});
 					} catch (e) {
 						const msg = String(e);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2021",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2021", "DOM"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "types": ["vite/client"],
 


### PR DESCRIPTION
## Summary

Fixes #39 — *"PostMergeCleanupDialog deletes the worktree even when the user keeps it."*

Root cause: `delete_local_branch_impl` in Rust unconditionally cascaded through `remove_worktree_by_branch` whenever the branch had a linked worktree, and `executeCleanup` had no way to express the user's intent to keep the worktree.

## Changes

### Rust — `src-tauri/src/worktree.rs`
- `delete_local_branch_impl` gains a `keep_worktree: bool` parameter.
  - `false` (default) → preserves existing cascade behaviour.
  - `true` → detaches the worktree HEAD (`git checkout --detach` inside the worktree) then runs `git branch -d <branch>` against the base repo. The worktree directory and its files survive.
- Tauri command `delete_local_branch` accepts `keep_worktree: Option<bool>` and forwards it; `None` keeps the old behaviour so other callsites (e.g. `useAutoDeleteBranch` on PR close) need no change.

### Frontend — `src/hooks/usePostMergeCleanup.ts`
- `executeCleanup` derives `keepWorktree` from the presence-and-unchecked-state of the `"worktree"` step and passes it to `invoke("delete_local_branch", …)`.

### Tests
- **Rust**: `delete_local_branch_should_preserve_worktree_when_user_keeps_it` asserts the post-fix contract (worktree dir + branch ref state after `keep_worktree=true`). Companion `delete_local_branch_with_worktree` retains the cascade-on-default-flag check.
- **Frontend**: `passes keepWorktree: true when user unchecks the worktree step` asserts the new invocation shape. Existing `delete_local_branch` assertions updated to expect `keepWorktree: false` when the step isn't present.

### Bundled cleanup (pre-existing, unrelated to #39)
Caught by `npx tsc --noEmit` while validating this PR — 10 pre-existing errors on upstream main:
- `tsconfig.json`: added `"DOM.Iterable"` to `lib` so `NodeListOf`, `DataTransferItemList`, `StyleSheetList` become iterable. Resolves errors in `TabBar`, `AIChatPanel`, `NotesPanel`, `PluginPanel`, `DomSearchEngine`, `ContentRenderer`, `DictationSettings`.
- `npm install`: materialised `mermaid` and `@crabnebula/tauri-plugin-drag` (declared in `package.json` but missing from `node_modules`). Resolves the two "Cannot find module" errors.

These were bundled in to keep `tsc` green for the worktree-bug review. Happy to split into a separate PR if reviewers prefer.

## Test plan

- [x] `cd src-tauri && cargo test --lib worktree::` → 49 passed, 0 failed (previously-failing regression test now green).
- [x] `npx vitest run` → 3910 passed, 0 failed.
- [x] `npx tsc --noEmit` → clean.
- [x] `cargo check --lib` → clean.
- [ ] Manual smoke (deferred to reviewer): merge a PR with a linked worktree, in PostMergeCleanupDialog uncheck "Archive/Delete worktree" and leave "Delete local branch" checked → expect the worktree directory + files to remain on disk, branch ref gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)