### PR TITLE
fix(worktrees): prevent sidebar resurrection of user-deleted worktrees

### DIFF
--- a/src/__tests__/hooks/useGitOperations.test.ts
+++ b/src/__tests__/hooks/useGitOperations.test.ts
@@ -1029,6 +1029,63 @@ describe("useGitOperations", () => {
 			// Branch should have been removed from the store
 			expect(repositoriesStore.get("/repo")?.branches["worktree-agent-abc"]).toBeUndefined();
 		});
+
+		it("does not resurrect a branch deleted by user while refresh was in-flight", async () => {
+			// Regression: refreshAllBranchStats fetches worktree_paths before the deletion
+			// completes. When the batch runs with stale data (deleted branch still in
+			// worktree_paths), setBranch must not re-add it if the user already removed it.
+			repositoriesStore.add({ path: "/repo", displayName: "Repo" });
+			repositoriesStore.setBranch("/repo", "main", { worktreePath: "/repo" });
+			repositoriesStore.setBranch("/repo", "feature", { worktreePath: "/repo/.worktrees/feature" });
+
+			// Hold getRepoStructure so we can inject a user deletion before it resolves
+			let resolveStructure!: (v: unknown) => void;
+			mockRepo.getRepoStructure.mockReturnValueOnce(new Promise((r) => (resolveStructure = r)));
+			mockRepo.getRepoDiffStats.mockResolvedValue({ diff_stats: {}, last_commit_ts: {} });
+
+			const refreshPromise = gitOps.refreshAllBranchStats();
+
+			// User deletes "feature" while refresh is awaiting getRepoStructure
+			repositoriesStore.removeBranch("/repo", "feature");
+
+			// Resolve with STALE data: "feature" still present in worktree_paths
+			resolveStructure({
+				worktree_paths: { main: "/repo", feature: "/repo/.worktrees/feature" },
+				merged_branches: [],
+			});
+
+			await refreshPromise;
+
+			// Refresh must not resurrect the user-deleted branch
+			expect(repositoriesStore.get("/repo")?.branches["feature"]).toBeUndefined();
+			expect(repositoriesStore.get("/repo")?.branches["main"]).toBeDefined();
+		});
+
+		it("still adds genuinely new external worktrees that were not in the snapshot", async () => {
+			// Guard: the race-condition fix must only skip branches that were in the
+			// snapshot AND are now gone. A brand-new external worktree (never in snapshot)
+			// must still be discovered and added.
+			repositoriesStore.add({ path: "/repo", displayName: "Repo" });
+			repositoriesStore.setBranch("/repo", "main", { worktreePath: "/repo" });
+
+			mockRepo.getRepoStructure.mockResolvedValue({
+				worktree_paths: { main: "/repo", "external-new": "/repo/.worktrees/external-new" },
+				merged_branches: [],
+			});
+			mockRepo.getRepoDiffStats.mockResolvedValue({
+				diff_stats: {
+					"/repo": { additions: 0, deletions: 0 },
+					"/repo/.worktrees/external-new": { additions: 2, deletions: 1 },
+				},
+				last_commit_ts: {},
+			});
+
+			await gitOps.refreshAllBranchStats();
+
+			const newBranch = repositoriesStore.get("/repo")?.branches["external-new"];
+			expect(newBranch).toBeDefined();
+			expect(newBranch?.worktreePath).toBe("/repo/.worktrees/external-new");
+		});
 	});
 
 	describe("refreshAllBranchStats — progressive loading", () => {

--- a/src/hooks/useGitOperations.ts
+++ b/src/hooks/useGitOperations.ts
@@ -200,6 +200,9 @@ export function useGitOperations(deps: GitOperationsDeps) {
 
 				const repo = repositoriesStore.get(repoPath);
 				if (!repo) return;
+				// Snapshot branch keys before any await so we can detect user-triggered
+				// removals that happen while async ops are in-flight (race condition guard).
+				const priorBranchKeys = new Set(Object.keys(repo.branches));
 				// Non-git directories: check if they became a git repo
 				if (repo.isGitRepo === false) {
 					try {
@@ -341,8 +344,15 @@ export function useGitOperations(deps: GitOperationsDeps) {
 				}
 
 				batch(() => {
+					// Guard against race: if a branch was present before our async ops
+					// but is now gone from the live store, the user deleted it while we
+					// were in-flight. Don't resurrect it via stale worktreePaths data.
+					const liveRepo = repositoriesStore.get(repoPath);
 					// Create new worktree branches first so mergeBranchState has a target
 					for (const [branchName, wtPath] of Object.entries(worktreePaths)) {
+						if (priorBranchKeys.has(branchName) && !liveRepo?.branches[branchName]) {
+							continue;
+						}
 						repositoriesStore.setBranch(repoPath, branchName, {
 							worktreePath: wtPath,
 							isMerged: mergedSet.has(branchName),


### PR DESCRIPTION
## Problem

When a user deletes a worktree/branch, it reappears in the sidebar immediately after.

**Root cause**: `refreshAllBranchStats` in `useGitOperations.ts` starts by reading `worktreePaths` from the store, then performs multiple `await` calls (git operations). If the user deletes a branch *during* those awaits, the post-await Phase 1 batch still iterates the stale `worktreePaths` and calls `repositoriesStore.setBranch` for the already-deleted branch — resurrecting it.

## Fix

Snapshot `Object.keys(repo.branches)` into a plain `Set` **before the first await**. In the Phase 1 loop, skip any branch that was in the snapshot but is now absent from the live store — that signals a user-triggered deletion in-flight, not a new external worktree.

```ts
// Before any await:
const priorBranchKeys = new Set(Object.keys(repo.branches));

// In Phase 1 batch loop:
const liveRepo = repositoriesStore.get(repoPath);
for (const [branchName, wtPath] of Object.entries(worktreePaths)) {
    if (priorBranchKeys.has(branchName) && !liveRepo?.branches[branchName]) {
        continue; // don't resurrect user-deleted branch
    }
    repositoriesStore.setBranch(repoPath, branchName, { ... });
}
```

**Why `Object.keys` and not the proxy itself?** SolidJS `repositoriesStore.get()` returns a live reactive proxy — accessing `.branches` after an await reads *current* state, not a snapshot. `new Set(Object.keys(...))` copies the keys at capture time.

## Tests

Two regression tests added to `useGitOperations.test.ts`:

1. `does not resurrect a branch deleted by user while refresh was in-flight` — deferred-promise technique to pause Phase 1 mid-flight, delete a branch, then resolve with stale data; asserts branch stays deleted.
2. `still adds genuinely new external worktrees that were not in the snapshot` — confirms new external worktrees (not present at snapshot time) still get added normally.

## Test plan

- [ ] Delete a worktree in TUICommander sidebar → it stays deleted
- [ ] Add an external worktree via CLI while app is open → it appears in sidebar
- [ ] `npx vitest run src/__tests__/hooks/useGitOperations.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)