### PR TITLE
fix(terminal): wrap multi-line paste in bracketed paste sequences

### DIFF
--- a/src/components/Terminal/CanvasTerminal.tsx
+++ b/src/components/Terminal/CanvasTerminal.tsx
@@ -2775,7 +2775,7 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 					.readText()
 					.then((text) => {
 						if (text) {
-							if (currentFrame?.bracketedPaste) {
+							if (currentFrame?.bracketedPaste || text.includes("\n")) {
 								writePty(`\x1b[200~${text}\x1b[201~`);
 							} else {
 								writePty(text);
@@ -2891,7 +2891,7 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 			}
 			const text = e.clipboardData?.getData("text");
 			if (text) {
-				if (currentFrame?.bracketedPaste) {
+				if (currentFrame?.bracketedPaste || text.includes("\n")) {
 					writePty(`\x1b[200~${text}\x1b[201~`);
 				} else {
 					writePty(text);

--- a/src/hooks/useTerminalLifecycle.ts
+++ b/src/hooks/useTerminalLifecycle.ts
@@ -412,7 +412,8 @@ export function useTerminalLifecycle(deps: TerminalLifecycleDeps) {
 			const text = await navigator.clipboard.readText();
 			const active = terminalsStore.getActive();
 			if (active?.ref && text) {
-				active.ref.write(text);
+				const payload = text.includes("\n") ? `\x1b[200~${text}\x1b[201~` : text;
+				active.ref.write(payload);
 			}
 		} catch (err) {
 			appLogger.error("terminal", "Failed to paste", err);


### PR DESCRIPTION
## Problem

Pasting multi-line text from clipboard into the terminal only pastes the first line (or lines execute as separate commands). The rest of the clipboard content is lost or causes unexpected command execution.

**Root cause**: When `bracketedPaste` mode is not announced by the shell, newlines in pasted text are sent raw. The shell interprets each `\n` as Enter, executing lines individually instead of treating the paste as a single atomic input.

## Fix

Force bracketed paste wrapping (`ESC[200~...ESC[201~`) whenever the pasted text contains `\n`, regardless of whether the shell announced bracketed paste support:

```ts
// Before:
if (currentFrame?.bracketedPaste) {
    writePty(`\x1b[200~${text}\x1b[201~`);
} else {
    writePty(text);
}

// After:
if (currentFrame?.bracketedPaste || text.includes("\n")) {
    writePty(`\x1b[200~${text}\x1b[201~`);
} else {
    writePty(text);
}
```

Applied in all three paste paths:
- Windows Ctrl+V keydown handler
- ClipboardEvent paste handler  
- Menu-driven `pasteToTerminal()` in `useTerminalLifecycle`

## Test plan

- [ ] Copy multi-line text → paste into terminal with bash → all lines appear as single input, not executed individually
- [ ] Copy multi-line text → paste into `vim` / `nano` → all lines inserted correctly
- [ ] Copy single-line text → paste → works normally without bracketed escape chars
- [ ] Paste via Edit menu → same behavior as keyboard shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)