### PR TITLE
fix(terminal): prevent permanent blank screen from stuck in_flight flag

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -2908,6 +2908,11 @@ pub(crate) fn spawn_reader_thread(
     let ticker_sid = session_id.clone();
     std::thread::spawn(move || {
         const TICK: std::time::Duration = std::time::Duration::from_millis(8);
+        // Safety net: if in_flight stays true for this long (~500 ms),
+        // force-reset it so frame delivery resumes. Prevents permanent blank
+        // terminal when the frontend fails to ack (crash, corrupt frame, etc.).
+        const MAX_IN_FLIGHT_MS: u64 = 500;
+        let mut stuck_since: Option<std::time::Instant> = None;
         while ticker_running.load(Ordering::Relaxed) {
             std::thread::sleep(TICK);
             if !ticker_dirty.swap(false, Ordering::Relaxed) {
@@ -2919,9 +2924,25 @@ pub(crate) fn spawn_reader_thread(
                 .map(|f| f.load(Ordering::Relaxed))
                 .unwrap_or(false);
             if in_flight {
-                // Re-set dirty so next tick retries
-                ticker_dirty.store(true, Ordering::Relaxed);
-                continue;
+                let now = std::time::Instant::now();
+                let since = stuck_since.get_or_insert(now);
+                let elapsed = now.duration_since(*since).as_millis() as u64;
+                if elapsed > MAX_IN_FLIGHT_MS {
+                    tracing::warn!(
+                        session_id = %ticker_sid,
+                        elapsed_ms = elapsed,
+                        "grid_frame_in_flight stuck, force-resetting"
+                    );
+                    if let Some(flag) = ticker_state.grid_frame_in_flight.get(&ticker_sid) {
+                        flag.store(false, Ordering::Relaxed);
+                    }
+                    stuck_since = None;
+                } else {
+                    ticker_dirty.store(true, Ordering::Relaxed);
+                    continue;
+                }
+            } else {
+                stuck_since = None;
             }
             if let Some(vt) = ticker_state.vt_log_buffers.get(&ticker_sid) {
                 let frame = vt.lock().serialize_dirty_rows();
@@ -4798,10 +4819,11 @@ pub(crate) fn ack_terminal_frame(state: State<'_, Arc<AppState>>, session_id: St
         // itself sends a frame that gets ACKed.
         if was_in_flight && let Some(vt) = state.vt_log_buffers.get(&session_id) {
             let frame = vt.lock().serialize_dirty_rows();
-            if !frame.is_empty()
-                && let Some(ch) = state.grid_channels.get(&session_id)
-            {
-                let _ = ch.send(frame);
+            if !frame.is_empty() {
+                // Use send_grid_frame instead of ch.send directly so that
+                // in_flight is properly tracked and the ticker doesn't send
+                // a duplicate frame concurrently.
+                send_grid_frame(&state, &session_id, frame);
             }
         }
     }

--- a/src/components/Terminal/CanvasTerminal.tsx
+++ b/src/components/Terminal/CanvasTerminal.tsx
@@ -2051,6 +2051,13 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 
 	function onFrame(data: ArrayBuffer | number[]) {
 		const buffer = data instanceof ArrayBuffer ? data : new Uint8Array(data).buffer;
+
+		// Ack BEFORE decode. If decodeBinaryFrame returns null (corrupt/truncated
+		// frame) or throws, the in-flight flag is still cleared so the backend
+		// can send the next frame. Previously a failed decode left in_flight
+		// stuck at true, permanently blocking frame delivery → blank terminal.
+		invokeRef?.("ack_terminal_frame", { sessionId: props.sessionId }).catch(ipcErr("ack_terminal_frame"));
+
 		const frame = decodeBinaryFrame(buffer);
 		if (!frame) return;
 
@@ -2110,11 +2117,6 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 				cachedSelectionText = "";
 			}
 		}
-
-		// Ack on receive, not after paint. Otherwise the backend is forced to wait
-		// until the frontend has displayed an intermediate PTY state (for example a
-		// newline carrying the previous SGR background before the CLI writes reset/text).
-		invokeRef?.("ack_terminal_frame", { sessionId: props.sessionId }).catch(ipcErr("ack_terminal_frame"));
 
 		if (hidden) return;
 		scheduleRepaint();
@@ -2548,13 +2550,25 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 				const isVisible = entries[0]?.isIntersecting ?? false;
 				if (isVisible && hidden) {
 					hidden = false;
-					rowMap.clear();
-					detectedLinks.clear();
 					fullRepaintNeeded = true;
-					currentFrame = null;
 					lastDisplayOffset = -1;
+					// Don't clear rowMap/currentFrame here — keep showing the
+					// last painted content until the fresh frame arrives.
+					// onFrame() replaces rowMap when a full frame arrives
+					// (rows.length >= screenRowCount), so stale data is
+					// naturally discarded without a blank flash.
 					remeasure();
-					invokeRef?.("terminal_request_frame", { sessionId: props.sessionId }).catch(ipcErr("terminal_request_frame"));
+					// If remeasure saw 0x0 (layout not yet computed after
+					// display:none → display:block), retry after a frame.
+					const rect = containerRef.getBoundingClientRect();
+					if (rect.width <= 0 || rect.height <= 0) {
+						requestAnimationFrame(() => {
+							remeasure();
+							invokeRef?.("terminal_request_frame", { sessionId: props.sessionId }).catch(ipcErr("terminal_request_frame"));
+						});
+					} else {
+						invokeRef?.("terminal_request_frame", { sessionId: props.sessionId }).catch(ipcErr("terminal_request_frame"));
+					}
 				} else if (!isVisible && !hidden) {
 					hidden = true;
 				}

--- a/src/components/Terminal/canvasTerminalTransport.ts
+++ b/src/components/Terminal/canvasTerminalTransport.ts
@@ -1,3 +1,4 @@
+import { appLogger } from "../../stores/appLogger";
 import { isTauri, rpc } from "../../transport";
 
 export interface TerminalTransport {
@@ -42,12 +43,13 @@ export class TauriTransport implements TerminalTransport {
 		Channel: new () => { onmessage: (data: ArrayBuffer | number[]) => void },
 	): Promise<void> {
 		const onFrame = this.onFrameHandler!;
+		const sessionId = this.sessionId;
 		const channel = new Channel();
 		channel.onmessage = (data: ArrayBuffer | number[]) => {
-			if (data instanceof ArrayBuffer) {
-				onFrame(data);
-			} else {
-				onFrame(new Uint8Array(data).buffer);
+			try {
+				onFrame(data instanceof ArrayBuffer ? data : new Uint8Array(data).buffer);
+			} catch (e) {
+				appLogger.error("terminal", "onFrame threw in channel callback", { sessionId, error: e });
 			}
 		};
 		await invoke("subscribe_terminal_grid", {


### PR DESCRIPTION
## Problem

The terminal occasionally goes completely blank — it keeps functioning (keystrokes are processed) but nothing is rendered. The only recovery is restarting the app.

**Root cause**: The `grid_frame_in_flight` flag implements flow control: only one frame is sent at a time, and the frontend must ack before the next is delivered. If `decodeBinaryFrame` fails (corrupt/truncated frame), the ack is never sent → `in_flight` stays `true` permanently → no more frames → blank terminal forever.

A secondary cause: when switching tabs, `rowMap` and `currentFrame` were cleared on visibility restore, causing a blank flash while waiting for the fresh frame. If the container had 0x0 dimensions at that moment (layout not yet computed), `remeasure()` would silently fail and no frame was ever requested.

## Fix

Defence in depth across 5 layers:

1. **Ack before decode** — move `ack_terminal_frame` before `decodeBinaryFrame` so the backend is unblocked even if decode fails:

```ts
// Before: ack was after decode + processing
const frame = decodeBinaryFrame(buffer);
if (!frame) return;
// ... process frame ...
invokeRef?.("ack_terminal_frame", ...);

// After: ack immediately on receive
invokeRef?.("ack_terminal_frame", ...);
const frame = decodeBinaryFrame(buffer);
if (!frame) return;
```

2. **Try/catch in channel callback** — wrap `onFrame` so an exception cannot kill the IPC channel.

3. **500ms safety-net timeout** in the Rust ticker thread — if `in_flight` stays true beyond 500ms, force-reset it and log a warning:

```rust
const MAX_IN_FLIGHT_MS: u64 = 500;
if elapsed > MAX_IN_FLIGHT_MS {
    tracing::warn!("grid_frame_in_flight stuck, force-resetting");
    flag.store(false, Ordering::Relaxed);
}
```

4. **Fix `ack_terminal_frame`** to use `send_grid_frame` (tracks `in_flight`) instead of raw `ch.send` (which could race with the ticker).

5. **Keep last-painted content on tab restore** — don't clear `rowMap`/`currentFrame` on visibility change. Handle 0x0 container race with `requestAnimationFrame` retry.

## Test plan

- [ ] Use terminal normally for extended period → no blank screen
- [ ] Switch between tabs rapidly → terminal content preserved, no blank flash
- [ ] Hide and show terminal tab → content visible immediately
- [ ] Check logs for `grid_frame_in_flight stuck` warning — should not appear under normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)