### PR TITLE
Add release version checking for OSX install.sh

### DIFF
--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -3,7 +3,8 @@
 set -e
 
 REPO="${TUICOMMANDER_REPO:-sstraus/tuicommander}"
-API_URL="https://api.github.com/repos/$REPO/releases/latest"
+API_URL="https://api.github.com/repos/$REPO"
+RELEASE_URL="$API_URL/releases"
 
 OSX_HOME="${TUICOMMANDER_HOME:-/Applications}"
 
@@ -12,12 +13,12 @@ if [ $# -gt 0 ] && [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     exit 1
 fi
 if [ $# -eq 1 ]; then
-    WANTED_VER="$1"
+    WANTED_VER="${1#v}"
     shift $((OPTIND - 1))
 fi
 
 get_download_url() {
-  curl -s "$API_URL" \
+  curl -s "$RELEASE_URL/latest" \
     | grep -o "\"browser_download_url\": *\"[^\"]*${1}\"" \
     | head -1 \
     | grep -o 'https://[^"]*'
@@ -33,7 +34,8 @@ install_macos() {
     # might not be in the usual place, but if the user has set up tuic we can find it from that
     if [ -e $(command -v tuic) ]; then
       local TUIC=$(readlink $(command -v tuic))
-      APP_HOME=${TUIC%/Contents/MacOS/tuic}
+      APP_HOME="${TUIC%/Contents/MacOS/tuic}"
+      OSX_HOME="${APP_HOME%/TUICommander.app}"
     fi
   fi
 
@@ -42,49 +44,81 @@ install_macos() {
     if [ -f "$APP_HOME/Contents/Info.plist" ]; then
       APP_VER=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$APP_HOME/Contents/Info.plist")
       if [ -n "$APP_VER" ]; then
+        # 1.3.0-nightly.20260603.t2024
+        # 1.3.0
         echo "Found ${APP_VER} currently installed"
       fi
     fi
   fi
 
-  # get the latest version from GitHub
-  # following is a bit of a hack to get the version to keep script external tool dependencies to built-in only
-  local LATEST_VER="unknown"
-  LATEST_VER=$(curl -sS --fail-with-body -L \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      "$API_URL" \
-      | grep "tag_name" \
-      | sed 's/^.*"v\([^"]*\)",$/\1/')
-  if [ $? -ne 0 ]; then
-    echo "Unable to get the latest version from GitHub"
-    exit 1
+  if [ -n "$APP_VER" ] && [ -z "$WANTED_VER" ]; then
+    # determine if the current installed version is a nightly as
+    # that has a slightly different version checking approach
+    echo "$APP_VER" | grep -q "nightly"
+    if [ $? -eq 0 ]; then
+      echo "Found current version to be a nightly version"
+      WANTED_VER="nightly"
+    fi
   fi
+
+  # get the latest version from GitHub
+  local LATEST_VER="unknown"
+  if [ "$WANTED_VER" == "nightly" ]; then
+    # fetch the latest json for nightly so we can find the version string there
+    # "version": "1.3.0-nightly.20260603.t2025",
+    LATEST_VER=$(curl -sS --fail-with-body -L \
+        "https://github.com/${REPO}/releases/download/nightly/latest.json" \
+        | grep '"version"' \
+        | sed 's/^.*": "\([^"]*\)",$/\1/')
+    if [ $? -ne 0 ]; then
+      echo "Unable to get the latest nightly version from GitHub"
+      exit 1
+    fi
+    echo "Found $LATEST_VER as latest nightly"
+
+    # nightly ver numbers can be slightly different between the actual app version found in Info.plist and the version found in latest.json
+    # so we strip off the tail end of the version strings -- as nightly is supposed to be once a day, we should be ok
+    LATEST_VER="${LATEST_VER%.t*}"
+    APP_VER="${APP_VER%.t*}"
+  elif [ -n "$WANTED_VER" ]; then
+    # no need to check GitHub, the user specified the version they want
+    LATEST_VER="v${WANTED_VER}"
+    APP_VER="v${APP_VER}"
+  else
+    # v1.3.0 -> 1.3.0
+    LATEST_VER=$(curl -sS --fail-with-body -L \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$RELEASE_URL/latest" \
+        | grep "tag_name" \
+        | sed 's/^.*": "v\([^"]*\)",$/\1/')
+    if [ $? -ne 0 ]; then
+      echo "Unable to get the latest version from GitHub"
+      exit 1
+    fi
+    echo "Found ${LATEST_VER} as latest release version"
+    LATEST_VER="v${LATEST_VER}"
+    APP_VER="v${APP_VER}"
+    WANTED_VER="v${LATEST_VER}"
+  fi
+
   if [ -z "$LATEST_VER" ]; then
     echo "Unable to determine latest version from GitHub"
     exit 1
-  fi
-  echo "Found ${LATEST_VER} as latest release version"
-
-  if [ -n "$WANTED_VER" ]; then
-    echo "Looking to install ${WANTED_VER} instead"
-    # TODO: should sanity check whether WANTED_VER actually exists -- but for now, it will just fail below
-    LATEST_VER="$WANTED_VER"
   fi
 
   if [ "$LATEST_VER" == "$APP_VER" ]; then
     echo "No need to update"
     exit 0
   fi
-exit
 
   local ASSET="TUICommander_aarch64.app.tar.gz"
-  local URL="https://github.com/$REPO/releases/download/v$LATEST_VER/$ASSET"
-  echo "Downloading $ASSET..."
+  local URL="https://github.com/$REPO/releases/download/$WANTED_VER/$ASSET"
+  echo "Downloading and installing version ${LATEST_VER}"
   curl -LSs "$URL" \
     | tar xz -C "$OSX_HOME"
   if [ $? -ne 0 ]; then
-    echo "Unable to download the latest version from GitHub"
+    echo "Unable to download version ${WANTED_VER} from GitHub"
     exit 1
   fi
   echo "Installed to ${OSX_HOME}/TUICommander.app"

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -27,8 +27,8 @@ install_macos() {
   local APP_HOME
   local APP_VER
 
-  if [ -d /Applications/TUICommander.app ]; then
-    APP_HOME="/Applications/TUICommander.app"
+  if [ -d "$OSX_HOME/TUICommander.app" ]; then
+    APP_HOME="$OSX_HOME/TUICommander.app"
   else
     # might not be in the usual place, but if the user has set up tuic we can find it from that
     if [ -e $(command -v tuic) ]; then

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
+# vim: set expandtab ts=2 sw=2 :
 set -e
 
-REPO="sstraus/tuicommander"
+REPO="${TUICOMMANDER_REPO:-sstraus/tuicommander}"
 API_URL="https://api.github.com/repos/$REPO/releases/latest"
+
+OSX_HOME="${TUICOMMANDER_HOME:-/Applications}"
+
+if [ $# -gt 0 ] && [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    echo "usage: $0 [version]"
+    exit 1
+fi
+if [ $# -eq 1 ]; then
+    WANTED_VER="$1"
+    shift $((OPTIND - 1))
+fi
 
 get_download_url() {
   curl -s "$API_URL" \
@@ -12,11 +24,70 @@ get_download_url() {
 }
 
 install_macos() {
-  ASSET="TUICommander_aarch64.app.tar.gz"
-  URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+  local APP_HOME
+  local APP_VER
+
+  if [ -d /Applications/TUICommander.app ]; then
+    APP_HOME="/Applications/TUICommander.app"
+  else
+    # might not be in the usual place, but if the user has set up tuic we can find it from that
+    if [ -e $(command -v tuic) ]; then
+      local TUIC=$(readlink $(command -v tuic))
+      APP_HOME=${TUIC%/Contents/MacOS/tuic}
+    fi
+  fi
+
+  if [ -n "$APP_HOME" ]; then
+    # verify it actually looks like the app
+    if [ -f "$APP_HOME/Contents/Info.plist" ]; then
+      APP_VER=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$APP_HOME/Contents/Info.plist")
+      if [ -n "$APP_VER" ]; then
+        echo "Found ${APP_VER} currently installed"
+      fi
+    fi
+  fi
+
+  # get the latest version from GitHub
+  # following is a bit of a hack to get the version to keep script external tool dependencies to built-in only
+  local LATEST_VER="unknown"
+  LATEST_VER=$(curl -sS --fail-with-body -L \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "$API_URL" \
+      | grep "tag_name" \
+      | sed 's/^.*"v\([^"]*\)",$/\1/')
+  if [ $? -ne 0 ]; then
+    echo "Unable to get the latest version from GitHub"
+    exit 1
+  fi
+  if [ -z "$LATEST_VER" ]; then
+    echo "Unable to determine latest version from GitHub"
+    exit 1
+  fi
+  echo "Found ${LATEST_VER} as latest release version"
+
+  if [ -n "$WANTED_VER" ]; then
+    echo "Looking to install ${WANTED_VER} instead"
+    # TODO: should sanity check whether WANTED_VER actually exists -- but for now, it will just fail below
+    LATEST_VER="$WANTED_VER"
+  fi
+
+  if [ "$LATEST_VER" == "$APP_VER" ]; then
+    echo "No need to update"
+    exit 0
+  fi
+exit
+
+  local ASSET="TUICommander_aarch64.app.tar.gz"
+  local URL="https://github.com/$REPO/releases/download/v$LATEST_VER/$ASSET"
   echo "Downloading $ASSET..."
-  curl -LSs "$URL" | tar xz -C /Applications
-  echo "Installed to /Applications/TUICommander.app"
+  curl -LSs "$URL" \
+    | tar xz -C "$OSX_HOME"
+  if [ $? -ne 0 ]; then
+    echo "Unable to download the latest version from GitHub"
+    exit 1
+  fi
+  echo "Installed to ${OSX_HOME}/TUICommander.app"
   echo "Tip: you can also install via Homebrew: brew install sstraus/tap/tuicommander"
 }
 
@@ -60,3 +131,5 @@ case "$OS" in
   Linux)  install_linux ;;
   *)      echo "Unsupported OS: $OS. Download manually from https://github.com/$REPO/releases"; exit 1 ;;
 esac
+
+exit 0


### PR DESCRIPTION
Affects OSX only

`install.sh` now:
* Checks for an existing installed app, and if found, determines the version
* Checks for the latest release version on GitHub
* Compares the two -- if the version is the same, does not download or install
* If the version is newer, will download and install the latest version

Also:
* Allows a user to pass in the version (as an arg on the command line) they would like to install instead of the most recent version such as `1.3.0` or `v1.3.0` which allows both non-latest updates and even downgrades from the current version
* Allows setting of an optional env var `TUICOMMANDER_HOME` before running to allow for installing it in a location other then `/Applications/`
* Allows setting of an optional env var `TUICOMMANDER_REPO` before running to allow for a different repo (default is `sstraus/tuicommander`) to check for the latest release
* Determines if the installed app is a nightly version and if so, will check for a newer nightly and download and install if found
* Allows for `nightly` to be passed in as an arg instead of a specific version number to switch from a release version to the nightly builds
* If the app has been installed in a non-standard location but `tuic` can be found via PATH we will use it to find the install base (ie instead of `/Applications/`) to install the app