### PR TITLE
feat(sidebar): collapsible terminal tab list under branch rows

### DIFF
--- a/src/__tests__/components/Sidebar.test.tsx
+++ b/src/__tests__/components/Sidebar.test.tsx
@@ -21,6 +21,8 @@ const {
 	mockReorderRepoInGroup,
 	mockMoveRepoBetweenGroups,
 	mockReorderGroups,
+	mockToggleBranchTabsExpanded,
+	mockSetBranchTabsExpanded,
 } = vi.hoisted(() => ({
 	mockToggleExpanded: vi.fn(),
 	mockToggleCollapsed: vi.fn(),
@@ -40,6 +42,8 @@ const {
 	mockReorderRepoInGroup: vi.fn(),
 	mockMoveRepoBetweenGroups: vi.fn(),
 	mockReorderGroups: vi.fn(),
+	mockToggleBranchTabsExpanded: vi.fn(),
+	mockSetBranchTabsExpanded: vi.fn(),
 }));
 
 // Mock stores before importing the component
@@ -75,6 +79,8 @@ vi.mock("../../stores/repositories", () => ({
 		isGroupFullyParked: vi.fn(() => false),
 		get: vi.fn(() => undefined),
 		setActive: vi.fn(),
+		toggleBranchTabsExpanded: mockToggleBranchTabsExpanded,
+		setBranchTabsExpanded: mockSetBranchTabsExpanded,
 	},
 }));
 
@@ -91,6 +97,7 @@ vi.mock("../../stores/terminals", () => ({
 		get: mockTerminalsGet,
 		isBusy: vi.fn(() => false),
 		onRemove: vi.fn(() => () => {}),
+		state: { activeId: null as string | null },
 	},
 }));
 
@@ -1047,6 +1054,167 @@ describe("Sidebar", () => {
 			const { container } = render(() => <Sidebar {...defaultProps()} />);
 			const branchItem = container.querySelector(".branchItem");
 			expect(branchItem!.classList.contains("hasActivity")).toBe(false);
+		});
+	});
+
+	describe("branch tab list", () => {
+		/** Find the .branchItem row whose name matches. */
+		function branchRow(container: HTMLElement, name: string): HTMLElement {
+			const label = Array.from(container.querySelectorAll(".branchName")).find((el) => el.textContent === name);
+			const row = label?.closest(".branchItem");
+			if (!row) throw new Error(`branch row "${name}" not found`);
+			return row as HTMLElement;
+		}
+
+		it("renders a chevron only when the branch has more than one terminal", () => {
+			setRepos({
+				"/repo1": makeRepo({
+					branches: {
+						main: { name: "main", isMain: true, worktreePath: null, terminals: ["t1"], additions: 0, deletions: 0 },
+						"feature/x": {
+							name: "feature/x",
+							isMain: false,
+							worktreePath: "/wt/x",
+							terminals: ["t2", "t3"],
+							additions: 0,
+							deletions: 0,
+						},
+					},
+				}),
+			});
+			const { container } = render(() => <Sidebar {...defaultProps()} />);
+			// Single-terminal "main" → no chevron; multi-terminal "feature/x" → one chevron.
+			expect(container.querySelectorAll(".branchTabsChevron").length).toBe(1);
+		});
+
+		it("renders one subitem per terminal when expanded and >1 terminal", () => {
+			mockTerminalsGet.mockImplementation(() => ({
+				name: "term",
+				shellState: "idle",
+				unseen: false,
+				awaitingInput: null,
+			}));
+			setRepos({
+				"/repo1": makeRepo({
+					branches: {
+						main: {
+							name: "main",
+							isMain: true,
+							worktreePath: null,
+							terminals: ["t1", "t2"],
+							additions: 0,
+							deletions: 0,
+							tabsExpanded: true,
+						},
+					},
+				}),
+			});
+			const { container } = render(() => <Sidebar {...defaultProps()} />);
+			expect(container.querySelectorAll(".branchTabItem").length).toBe(2);
+		});
+
+		it("does not render subitems when branch has a single terminal even if tabsExpanded", () => {
+			mockTerminalsGet.mockImplementation(() => ({
+				name: "term",
+				shellState: "idle",
+				unseen: false,
+				awaitingInput: null,
+			}));
+			setRepos({
+				"/repo1": makeRepo({
+					branches: {
+						main: {
+							name: "main",
+							isMain: true,
+							worktreePath: null,
+							terminals: ["t1"],
+							additions: 0,
+							deletions: 0,
+							tabsExpanded: true,
+						},
+					},
+				}),
+			});
+			const { container } = render(() => <Sidebar {...defaultProps()} />);
+			expect(container.querySelectorAll(".branchTabItem").length).toBe(0);
+		});
+
+		it("toggles the tab list when re-clicking the already-active branch (>1 terminal)", () => {
+			setRepos(
+				{
+					"/repo1": makeRepo({
+						activeBranch: "main",
+						branches: {
+							main: {
+								name: "main",
+								isMain: true,
+								worktreePath: null,
+								terminals: ["t1", "t2"],
+								additions: 0,
+								deletions: 0,
+							},
+						},
+					}),
+				},
+				"/repo1",
+			);
+			const onBranchSelect = vi.fn();
+			const { container } = render(() => <Sidebar {...defaultProps({ onBranchSelect })} />);
+
+			fireEvent.click(branchRow(container, "main"));
+
+			expect(onBranchSelect).toHaveBeenCalledWith("/repo1", "main");
+			expect(mockToggleBranchTabsExpanded).toHaveBeenCalledWith("/repo1", "main");
+			expect(mockSetBranchTabsExpanded).not.toHaveBeenCalled();
+		});
+
+		it("opens (never toggles) when focusing a branch that was not active", () => {
+			setRepos(
+				{
+					"/repo1": makeRepo({
+						activeBranch: "main",
+						branches: {
+							main: { name: "main", isMain: true, worktreePath: null, terminals: ["t1"], additions: 0, deletions: 0 },
+							"feature/x": {
+								name: "feature/x",
+								isMain: false,
+								worktreePath: "/wt/x",
+								terminals: ["t2", "t3"],
+								additions: 0,
+								deletions: 0,
+								tabsExpanded: false,
+							},
+						},
+					}),
+				},
+				"/repo1",
+			);
+			const { container } = render(() => <Sidebar {...defaultProps()} />);
+
+			fireEvent.click(branchRow(container, "feature/x"));
+
+			expect(mockSetBranchTabsExpanded).toHaveBeenCalledWith("/repo1", "feature/x", true);
+			expect(mockToggleBranchTabsExpanded).not.toHaveBeenCalled();
+		});
+
+		it("does not open or toggle when the branch has a single terminal", () => {
+			setRepos(
+				{
+					"/repo1": makeRepo({
+						activeBranch: "main",
+						branches: {
+							main: { name: "main", isMain: true, worktreePath: null, terminals: ["t1"], additions: 0, deletions: 0 },
+						},
+					}),
+				},
+				"/repo1",
+			);
+			const { container } = render(() => <Sidebar {...defaultProps()} />);
+
+			fireEvent.click(branchRow(container, "main"));
+
+			expect(mockToggleBranchTabsExpanded).not.toHaveBeenCalled();
+			expect(mockSetBranchTabsExpanded).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/__tests__/stores/repositories.test.ts
+++ b/src/__tests__/stores/repositories.test.ts
@@ -554,6 +554,34 @@ describe("repositoriesStore", () => {
 		});
 	});
 
+	describe("toggleBranchTabsExpanded()", () => {
+		it("toggles tabsExpanded from undefined to true", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBeUndefined();
+				store.toggleBranchTabsExpanded("/repo", "feat/foo");
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(true);
+			});
+		});
+
+		it("toggles tabsExpanded from true to false", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				store.toggleBranchTabsExpanded("/repo", "feat/foo");
+				store.toggleBranchTabsExpanded("/repo", "feat/foo");
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(false);
+			});
+		});
+
+		it("no-ops on unknown repo/branch", () => {
+			testInScope(() => {
+				expect(() => store.toggleBranchTabsExpanded("/nonexistent", "main")).not.toThrow();
+			});
+		});
+	});
+
 	describe("isEmpty()", () => {
 		it("returns true when empty", () => {
 			testInScope(() => {

--- a/src/__tests__/stores/repositories.test.ts
+++ b/src/__tests__/stores/repositories.test.ts
@@ -593,6 +593,43 @@ describe("repositoriesStore", () => {
 		});
 	});
 
+	describe("setBranchTabsExpanded()", () => {
+		it("sets tabsExpanded to true", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				store.setBranchTabsExpanded("/repo", "feat/foo", true);
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(true);
+			});
+		});
+
+		it("keeps tabsExpanded true when set true again (idempotent open)", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				store.setBranchTabsExpanded("/repo", "feat/foo", true);
+				store.setBranchTabsExpanded("/repo", "feat/foo", true);
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(true);
+			});
+		});
+
+		it("sets tabsExpanded to false", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				store.setBranchTabsExpanded("/repo", "feat/foo", true);
+				store.setBranchTabsExpanded("/repo", "feat/foo", false);
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(false);
+			});
+		});
+
+		it("no-ops on unknown repo/branch", () => {
+			testInScope(() => {
+				expect(() => store.setBranchTabsExpanded("/nonexistent", "main", true)).not.toThrow();
+			});
+		});
+	});
+
 	describe("isEmpty()", () => {
 		it("returns true when empty", () => {
 			testInScope(() => {

--- a/src/__tests__/stores/repositories.test.ts
+++ b/src/__tests__/stores/repositories.test.ts
@@ -555,11 +555,11 @@ describe("repositoriesStore", () => {
 	});
 
 	describe("toggleBranchTabsExpanded()", () => {
-		it("toggles tabsExpanded from undefined to true", () => {
+		it("toggles tabsExpanded from falsy to true", () => {
 			testInScope(() => {
 				store.add({ path: "/repo", displayName: "My Repo" });
 				store.setBranch("/repo", "feat/foo");
-				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBeUndefined();
+				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBeFalsy();
 				store.toggleBranchTabsExpanded("/repo", "feat/foo");
 				expect(store.state.repositories["/repo"].branches["feat/foo"].tabsExpanded).toBe(true);
 			});
@@ -578,6 +578,17 @@ describe("repositoriesStore", () => {
 		it("no-ops on unknown repo/branch", () => {
 			testInScope(() => {
 				expect(() => store.toggleBranchTabsExpanded("/nonexistent", "main")).not.toThrow();
+			});
+		});
+
+		it("persists via save_repositories (debounced)", () => {
+			testInScope(() => {
+				store.add({ path: "/repo", displayName: "My Repo" });
+				store.setBranch("/repo", "feat/foo");
+				store.toggleBranchTabsExpanded("/repo", "feat/foo");
+				vi.advanceTimersByTime(500);
+				const calls = mockInvoke.mock.calls.filter((c: unknown[]) => c[0] === "save_repositories");
+				expect(calls.length).toBeGreaterThan(0);
 			});
 		});
 	});

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -26,6 +26,7 @@ import { PromptDialog } from "../PromptDialog";
 import b from "../shared/branch.module.css";
 import s from "./Sidebar.module.css";
 import { SidebarPluginSection } from "./SidebarPluginSection";
+import { navigateToTerminal } from "../../utils/navigateToTerminal";
 
 const BRANCH_ICON_CLASSES: Record<string, string> = {
 	main: s.branchIconMain,
@@ -192,6 +193,43 @@ export const PrStateBadge: Component<{
 };
 
 export { _resetMergedActivityAccum };
+
+/** Collapsible list of terminal tabs under a branch row */
+const BranchTabList: Component<{ terminalIds: string[] }> = (props) => {
+	return (
+		<div class={s.branchTabList} role="list">
+			<For each={props.terminalIds}>
+				{(id) => {
+					const term = () => terminalsStore.get(id);
+					const dotClass = () => {
+						const t = term();
+						if (!t) return s.branchTabDot;
+						if (t.awaitingInput === "error") return cx(s.branchTabDot, s.branchTabDotError);
+						if (t.awaitingInput === "question") return cx(s.branchTabDot, s.branchTabDotQuestion);
+						if (terminalsStore.isBusy(id)) return cx(s.branchTabDot, s.branchTabDotBusy);
+						if (t.unseen) return cx(s.branchTabDot, s.branchTabDotUnseen);
+						if (t.shellState === "idle") return cx(s.branchTabDot, s.branchTabDotIdle);
+						return s.branchTabDot;
+					};
+
+					return (
+						<Show when={term()}>
+							<div
+								class={s.branchTabItem}
+								role="listitem"
+								onClick={() => navigateToTerminal(id)}
+								title={term()?.name}
+							>
+								<span class={dotClass()} aria-hidden="true" />
+								<span class={s.branchTabName}>{term()?.name}</span>
+							</div>
+						</Show>
+					);
+				}}
+			</For>
+		</div>
+	);
+};
 
 /** Branch item component */
 export const BranchItem: Component<{
@@ -498,6 +536,20 @@ export const BranchItem: Component<{
 					visible={ctxMenu.visible()}
 					onClose={ctxMenu.close}
 				/>
+				<Show when={props.branch.terminals.length > 0}>
+					<button
+						class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)}
+						title={props.branch.tabsExpanded ? "Hide tabs" : "Show tabs"}
+						aria-label={props.branch.tabsExpanded ? "Collapse terminal tabs" : "Expand terminal tabs"}
+						aria-expanded={props.branch.tabsExpanded ?? false}
+						onClick={(e) => {
+							e.stopPropagation();
+							repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
+						}}
+					>
+						›
+					</button>
+				</Show>
 			</div>
 		</Show>
 	);
@@ -748,36 +800,46 @@ export const RepoSection: Component<{
 				<div class={s.repoBranches}>
 					<For each={sortedBranches()}>
 						{(branch, index) => (
-							<BranchItem
-								branch={branch}
-								repoPath={props.repo.path}
-								isActive={
-									repositoriesStore.state.activeRepoPath === props.repo.path && props.repo.activeBranch === branch.name
-								}
-								canRemove={canRemoveAny()}
-								shortcutIndex={props.quickSwitcherActive ? props.branchShortcutStart + index() : undefined}
-								agentMenuItems={props.buildAgentMenuItems ? () => props.buildAgentMenuItems!(branch.name) : undefined}
-								onSelect={() => props.onBranchSelect(branch.name)}
-								onAddTerminal={() => props.onAddTerminal(branch.name)}
-								isRemoving={props.removingBranches?.has(`${props.repo.path}::${branch.name}`)}
-								onRemove={() => props.onRemoveBranch(branch.name)}
-								onRename={() => props.onRenameBranch(branch.name)}
-								onCreateBranch={props.onCreateBranch ? () => props.onCreateBranch!(branch.name) : undefined}
-								onSetLabel={(current) => setLabelDialogBranch({ name: branch.name, current })}
-								onShowPrDetail={() => props.onShowPrDetail(branch.name)}
-								onShowChanges={props.onShowChanges}
-								onCreateWorktreeFromBranch={
-									props.onCreateWorktreeFromBranch ? () => props.onCreateWorktreeFromBranch!(branch.name) : undefined
-								}
-								onMergeAndArchive={props.onMergeAndArchive ? () => props.onMergeAndArchive!(branch.name) : undefined}
-								onSwitchBranch={
-									branch.worktreePath === props.repo.path ? (name) => props.onSwitchBranch(name) : undefined
-								}
-								switchBranchList={branch.worktreePath === props.repo.path ? props.switchBranchList : undefined}
-								currentBranch={branch.worktreePath === props.repo.path ? props.currentBranch : undefined}
-								githubBaseUrl={githubBaseUrl()}
-								repoHasTerminals={repoHasTerminals()}
-							/>
+							<>
+								<BranchItem
+									branch={branch}
+									repoPath={props.repo.path}
+									isActive={
+										repositoriesStore.state.activeRepoPath === props.repo.path &&
+										props.repo.activeBranch === branch.name
+									}
+									canRemove={canRemoveAny()}
+									shortcutIndex={props.quickSwitcherActive ? props.branchShortcutStart + index() : undefined}
+									agentMenuItems={props.buildAgentMenuItems ? () => props.buildAgentMenuItems!(branch.name) : undefined}
+									onSelect={() => props.onBranchSelect(branch.name)}
+									onAddTerminal={() => props.onAddTerminal(branch.name)}
+									isRemoving={props.removingBranches?.has(`${props.repo.path}::${branch.name}`)}
+									onRemove={() => props.onRemoveBranch(branch.name)}
+									onRename={() => props.onRenameBranch(branch.name)}
+									onCreateBranch={props.onCreateBranch ? () => props.onCreateBranch!(branch.name) : undefined}
+									onSetLabel={(current) => setLabelDialogBranch({ name: branch.name, current })}
+									onShowPrDetail={() => props.onShowPrDetail(branch.name)}
+									onShowChanges={props.onShowChanges}
+									onCreateWorktreeFromBranch={
+										props.onCreateWorktreeFromBranch
+											? () => props.onCreateWorktreeFromBranch!(branch.name)
+											: undefined
+									}
+									onMergeAndArchive={
+										props.onMergeAndArchive ? () => props.onMergeAndArchive!(branch.name) : undefined
+									}
+									onSwitchBranch={
+										branch.worktreePath === props.repo.path ? (name) => props.onSwitchBranch(name) : undefined
+									}
+									switchBranchList={branch.worktreePath === props.repo.path ? props.switchBranchList : undefined}
+									currentBranch={branch.worktreePath === props.repo.path ? props.currentBranch : undefined}
+									githubBaseUrl={githubBaseUrl()}
+									repoHasTerminals={repoHasTerminals()}
+								/>
+								<Show when={branch.tabsExpanded && branch.terminals.length > 0}>
+									<BranchTabList terminalIds={branch.terminals} />
+								</Show>
+							</>
 						)}
 					</For>
 					<Show when={sortedBranches().length === 0}>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -287,6 +287,16 @@ export const BranchItem: Component<{
 		}
 	};
 
+	// Clicking the row selects the branch and toggles its tab list. Child controls
+	// that own an action (PR badge, diff stats, add-terminal, remove) stopPropagation,
+	// so they never reach here.
+	const handleRowClick = () => {
+		props.onSelect();
+		if (props.branch.terminals.length > 0) {
+			repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
+		}
+	};
+
 	const handleCopyPath = async () => {
 		const path = props.branch.worktreePath;
 		if (path) {
@@ -432,7 +442,12 @@ export const BranchItem: Component<{
 				</div>
 			}
 		>
-			<div class={cx(s.branchItem, props.isActive && s.active)} onClick={props.onSelect} onContextMenu={ctxMenu.open}>
+			<div
+				class={cx(s.branchItem, props.isActive && s.active)}
+				onClick={handleRowClick}
+				onContextMenu={ctxMenu.open}
+				aria-expanded={props.branch.terminals.length > 0 ? (props.branch.tabsExpanded ?? false) : undefined}
+			>
 				<BranchIcon
 					isMainBranch={props.branch.isMain}
 					isMainWorktree={props.branch.worktreePath === props.repoPath}
@@ -540,17 +555,9 @@ export const BranchItem: Component<{
 					onClose={ctxMenu.close}
 				/>
 				<Show when={props.branch.terminals.length > 0}>
-					<button
-						class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)}
-						aria-label={props.branch.tabsExpanded ? "Collapse terminal tabs" : "Expand terminal tabs"}
-						aria-expanded={props.branch.tabsExpanded ?? false}
-						onClick={(e) => {
-							e.stopPropagation();
-							repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
-						}}
-					>
+					<span class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)} aria-hidden="true">
 						›
-					</button>
+					</span>
 				</Show>
 			</div>
 		</Show>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -287,19 +287,14 @@ export const BranchItem: Component<{
 		}
 	};
 
-	// Clicking the row always selects the branch. The tab-list toggle only fires
-	// when the branch was ALREADY active before this click — so clicking an
-	// unfocused branch just focuses it, and a second click on the now-active
-	// branch toggles its tabs. We must read isActive BEFORE onSelect(), since
-	// onSelect synchronously flips the branch to active. Tabs only exist when a
-	// branch has more than one terminal. Child controls that own an action (PR
-	// badge, diff stats, add-terminal, remove) stopPropagation, so they never
-	// reach here.
+	// Clicking the row selects the branch and always expands its tab list (never
+	// collapses) — an already-open list stays open. Tabs only exist when a branch
+	// has more than one terminal. Child controls that own an action (PR badge,
+	// diff stats, add-terminal, remove) stopPropagation, so they never reach here.
 	const handleRowClick = () => {
-		const wasActive = props.isActive;
 		props.onSelect();
-		if (wasActive && props.branch.terminals.length > 1) {
-			repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
+		if (props.branch.terminals.length > 1 && !props.branch.tabsExpanded) {
+			repositoriesStore.setBranchTabsExpanded(props.repoPath, props.branch.name, true);
 		}
 	};
 

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -542,7 +542,6 @@ export const BranchItem: Component<{
 				<Show when={props.branch.terminals.length > 0}>
 					<button
 						class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)}
-						title={props.branch.tabsExpanded ? "Hide tabs" : "Show tabs"}
 						aria-label={props.branch.tabsExpanded ? "Collapse terminal tabs" : "Expand terminal tabs"}
 						aria-expanded={props.branch.tabsExpanded ?? false}
 						onClick={(e) => {

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -197,7 +197,7 @@ export { _resetMergedActivityAccum };
 /** Collapsible list of terminal tabs under a branch row */
 const BranchTabList: Component<{ terminalIds: string[] }> = (props) => {
 	return (
-		<div class={s.branchTabList} role="list">
+		<div class={s.branchTabList} role="list" aria-label="Terminal tabs">
 			<For each={props.terminalIds}>
 				{(id) => {
 					const term = () => terminalsStore.get(id);
@@ -214,15 +214,17 @@ const BranchTabList: Component<{ terminalIds: string[] }> = (props) => {
 
 					return (
 						<Show when={term()}>
-							<div
-								class={s.branchTabItem}
-								role="listitem"
-								onClick={() => navigateToTerminal(id)}
-								title={term()?.name}
-							>
-								<span class={dotClass()} aria-hidden="true" />
-								<span class={s.branchTabName}>{term()?.name}</span>
-							</div>
+							{(t) => (
+								<button
+									class={s.branchTabItem}
+									role="listitem"
+									onClick={() => navigateToTerminal(id)}
+									title={t().name}
+								>
+									<span class={dotClass()} aria-hidden="true" />
+									<span class={s.branchTabName}>{t().name}</span>
+								</button>
+							)}
 						</Show>
 					);
 				}}

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -288,13 +288,17 @@ export const BranchItem: Component<{
 	};
 
 	// Clicking the row always selects the branch. The tab-list toggle only fires
-	// when the branch is already active — so clicking an unfocused branch just
-	// focuses it, and a second click on the now-active branch toggles its tabs.
-	// Child controls that own an action (PR badge, diff stats, add-terminal,
-	// remove) stopPropagation, so they never reach here.
+	// when the branch was ALREADY active before this click — so clicking an
+	// unfocused branch just focuses it, and a second click on the now-active
+	// branch toggles its tabs. We must read isActive BEFORE onSelect(), since
+	// onSelect synchronously flips the branch to active. Tabs only exist when a
+	// branch has more than one terminal. Child controls that own an action (PR
+	// badge, diff stats, add-terminal, remove) stopPropagation, so they never
+	// reach here.
 	const handleRowClick = () => {
+		const wasActive = props.isActive;
 		props.onSelect();
-		if (props.isActive && props.branch.terminals.length > 0) {
+		if (wasActive && props.branch.terminals.length > 1) {
 			repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
 		}
 	};
@@ -448,7 +452,7 @@ export const BranchItem: Component<{
 				class={cx(s.branchItem, props.isActive && s.active)}
 				onClick={handleRowClick}
 				onContextMenu={ctxMenu.open}
-				aria-expanded={props.branch.terminals.length > 0 ? (props.branch.tabsExpanded ?? false) : undefined}
+				aria-expanded={props.branch.terminals.length > 1 ? (props.branch.tabsExpanded ?? false) : undefined}
 			>
 				<BranchIcon
 					isMainBranch={props.branch.isMain}
@@ -556,7 +560,7 @@ export const BranchItem: Component<{
 					visible={ctxMenu.visible()}
 					onClose={ctxMenu.close}
 				/>
-				<Show when={props.branch.terminals.length > 0}>
+				<Show when={props.branch.terminals.length > 1}>
 					<span class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)} aria-hidden="true">
 						›
 					</span>
@@ -814,7 +818,7 @@ export const RepoSection: Component<{
 							<div
 								class={cx(
 									s.branchGroup,
-									branch.tabsExpanded && branch.terminals.length > 0 && s.branchGroupExpanded,
+									branch.tabsExpanded && branch.terminals.length > 1 && s.branchGroupExpanded,
 								)}
 							>
 								<BranchItem
@@ -852,7 +856,7 @@ export const RepoSection: Component<{
 									githubBaseUrl={githubBaseUrl()}
 									repoHasTerminals={repoHasTerminals()}
 								/>
-								<Show when={branch.tabsExpanded && branch.terminals.length > 0}>
+								<Show when={branch.tabsExpanded && branch.terminals.length > 1}>
 									<BranchTabList terminalIds={branch.terminals} />
 								</Show>
 							</div>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -287,13 +287,21 @@ export const BranchItem: Component<{
 		}
 	};
 
-	// Clicking the row selects the branch and always expands its tab list (never
-	// collapses) — an already-open list stays open. Tabs only exist when a branch
-	// has more than one terminal. Child controls that own an action (PR badge,
-	// diff stats, add-terminal, remove) stopPropagation, so they never reach here.
+	// Clicking the row selects the branch and manages its tab list:
+	//  - Returning focus from elsewhere (branch was NOT active) → expand (open
+	//    stays open, never collapses on a focus-switch).
+	//  - Re-clicking the already-focused branch → toggle (so it can be closed).
+	// We read isActive BEFORE onSelect(), since onSelect synchronously flips the
+	// branch to active. Tabs only exist when a branch has more than one terminal.
+	// Child controls that own an action (PR badge, diff stats, add-terminal,
+	// remove) stopPropagation, so they never reach here.
 	const handleRowClick = () => {
+		const wasActive = props.isActive;
 		props.onSelect();
-		if (props.branch.terminals.length > 1 && !props.branch.tabsExpanded) {
+		if (props.branch.terminals.length <= 1) return;
+		if (wasActive) {
+			repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
+		} else if (!props.branch.tabsExpanded) {
 			repositoriesStore.setBranchTabsExpanded(props.repoPath, props.branch.name, true);
 		}
 	};

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -802,7 +802,12 @@ export const RepoSection: Component<{
 				<div class={s.repoBranches}>
 					<For each={sortedBranches()}>
 						{(branch, index) => (
-							<>
+							<div
+								class={cx(
+									s.branchGroup,
+									branch.tabsExpanded && branch.terminals.length > 0 && s.branchGroupExpanded,
+								)}
+							>
 								<BranchItem
 									branch={branch}
 									repoPath={props.repo.path}
@@ -841,7 +846,7 @@ export const RepoSection: Component<{
 								<Show when={branch.tabsExpanded && branch.terminals.length > 0}>
 									<BranchTabList terminalIds={branch.terminals} />
 								</Show>
-							</>
+							</div>
 						)}
 					</For>
 					<Show when={sortedBranches().length === 0}>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -540,7 +540,7 @@ export const BranchItem: Component<{
 				/>
 				<Show when={props.branch.terminals.length > 0}>
 					<button
-						class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)}
+						class={cx(s.branchTabsCountBadge, props.branch.tabsExpanded && s.expanded)}
 						title={props.branch.tabsExpanded ? "Hide tabs" : "Show tabs"}
 						aria-label={props.branch.tabsExpanded ? "Collapse terminal tabs" : "Expand terminal tabs"}
 						aria-expanded={props.branch.tabsExpanded ?? false}
@@ -549,7 +549,7 @@ export const BranchItem: Component<{
 							repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
 						}}
 					>
-						›
+						{props.branch.terminals.length}
 					</button>
 				</Show>
 			</div>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -201,6 +201,7 @@ const BranchTabList: Component<{ terminalIds: string[] }> = (props) => {
 			<For each={props.terminalIds}>
 				{(id) => {
 					const term = () => terminalsStore.get(id);
+					const isActive = () => terminalsStore.state.activeId === id;
 					const dotClass = () => {
 						const t = term();
 						if (!t) return s.branchTabDot;
@@ -216,7 +217,7 @@ const BranchTabList: Component<{ terminalIds: string[] }> = (props) => {
 						<Show when={term()}>
 							{(t) => (
 								<button
-									class={s.branchTabItem}
+									class={cx(s.branchTabItem, isActive() && s.active)}
 									role="listitem"
 									onClick={() => navigateToTerminal(id)}
 									title={t().name}
@@ -540,7 +541,7 @@ export const BranchItem: Component<{
 				/>
 				<Show when={props.branch.terminals.length > 0}>
 					<button
-						class={cx(s.branchTabsCountBadge, props.branch.tabsExpanded && s.expanded)}
+						class={cx(s.branchTabsChevron, props.branch.tabsExpanded && s.expanded)}
 						title={props.branch.tabsExpanded ? "Hide tabs" : "Show tabs"}
 						aria-label={props.branch.tabsExpanded ? "Collapse terminal tabs" : "Expand terminal tabs"}
 						aria-expanded={props.branch.tabsExpanded ?? false}
@@ -549,7 +550,7 @@ export const BranchItem: Component<{
 							repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
 						}}
 					>
-						{props.branch.terminals.length}
+						›
 					</button>
 				</Show>
 			</div>

--- a/src/components/Sidebar/RepoSection.tsx
+++ b/src/components/Sidebar/RepoSection.tsx
@@ -287,12 +287,14 @@ export const BranchItem: Component<{
 		}
 	};
 
-	// Clicking the row selects the branch and toggles its tab list. Child controls
-	// that own an action (PR badge, diff stats, add-terminal, remove) stopPropagation,
-	// so they never reach here.
+	// Clicking the row always selects the branch. The tab-list toggle only fires
+	// when the branch is already active — so clicking an unfocused branch just
+	// focuses it, and a second click on the now-active branch toggles its tabs.
+	// Child controls that own an action (PR badge, diff stats, add-terminal,
+	// remove) stopPropagation, so they never reach here.
 	const handleRowClick = () => {
 		props.onSelect();
-		if (props.branch.terminals.length > 0) {
+		if (props.isActive && props.branch.terminals.length > 0) {
 			repositoriesStore.toggleBranchTabsExpanded(props.repoPath, props.branch.name);
 		}
 	};

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -499,6 +499,24 @@
   white-space: nowrap;
 }
 
+/* Branch group — wraps a branch row + its collapsible terminal tab list.
+   When expanded, hovering anywhere over the block lifts the whole group as a
+   unified card (DIA-style), while individual items keep their own stronger hover. */
+.branchGroup {
+  border-radius: var(--radius-lg);
+  transition: background 0.15s ease;
+}
+
+.branchGroupExpanded {
+  padding-bottom: 3px;
+}
+
+@media (hover: hover) {
+  .branchGroupExpanded:hover {
+    background: rgba(255, 255, 255, 0.035);
+  }
+}
+
 /* Branch tab list — collapsible terminal tab list under branch row */
 .branchTabsChevron {
   background: none;

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -499,6 +499,97 @@
   white-space: nowrap;
 }
 
+/* Branch tab list — collapsible terminal tab list under branch row */
+.branchTabsChevron {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 10px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: transform 150ms ease, color 0.1s;
+  transform: rotate(0deg);
+  opacity: 0.6;
+}
+
+.branchTabsChevron:hover {
+  color: var(--fg-secondary);
+  opacity: 1;
+}
+
+.branchTabsChevron.expanded {
+  transform: rotate(90deg);
+}
+
+.branchTabList {
+  padding: 2px 0 2px 28px;
+}
+
+.branchTabItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px 3px 4px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-sm);
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.1s;
+}
+
+@media (hover: hover) {
+  .branchTabItem:hover {
+    background: var(--bg-highlight);
+    color: var(--fg-primary);
+  }
+}
+
+.branchTabDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--fg-muted);
+  opacity: 0.4;
+}
+
+.branchTabDotBusy {
+  background: var(--activity);
+  opacity: 1;
+  animation: pulse-opacity 1.5s ease-in-out infinite;
+}
+
+.branchTabDotIdle {
+  background: var(--success);
+  opacity: 1;
+}
+
+.branchTabDotUnseen {
+  background: var(--unseen);
+  opacity: 1;
+}
+
+.branchTabDotError {
+  background: var(--error);
+  opacity: 1;
+}
+
+.branchTabDotQuestion {
+  background: var(--attention);
+  opacity: 1;
+}
+
+.branchTabName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .mergedBadge {
   display: inline-flex;
   align-items: center;

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -544,7 +544,11 @@
 }
 
 .branchTabList {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
   padding: 2px 0 4px 0;
+  margin: 0 2px 0 8px;
 }
 
 .branchTabItem {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -500,27 +500,34 @@
 }
 
 /* Branch tab list — collapsible terminal tab list under branch row */
-.branchTabsChevron {
-  background: none;
-  border: none;
-  color: var(--fg-muted);
-  font-size: 10px;
-  cursor: pointer;
-  padding: 0 2px;
-  line-height: 1;
+.branchTabsCountBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  font-size: var(--font-2xs);
+  font-weight: 600;
+  font-family: var(--font-ui);
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
   flex-shrink: 0;
-  transition: transform 150ms ease, color 0.1s;
-  transform: rotate(0deg);
-  opacity: 0.6;
+  cursor: pointer;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--fg-muted);
+  opacity: 0.7;
+  transition: background 0.1s, color 0.1s, opacity 0.1s;
 }
 
-.branchTabsChevron:hover {
-  color: var(--fg-secondary);
+.branchTabsCountBadge:hover {
   opacity: 1;
+  background: var(--bg-highlight);
+  color: var(--fg-secondary);
 }
 
-.branchTabsChevron.expanded {
-  transform: rotate(90deg);
+.branchTabsCountBadge.expanded {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  opacity: 1;
 }
 
 .branchTabList {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -548,7 +548,7 @@
   flex-direction: column;
   gap: 3px;
   padding: 2px 0 4px 0;
-  margin: 0 2px 0 8px;
+  margin: 0 2px 0 4px;
 }
 
 .branchTabItem {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -548,14 +548,16 @@
   flex-direction: column;
   gap: 3px;
   padding: 2px 0 4px 0;
-  margin: 0 2px 0 4px;
+  /* Left margin = branch row padding (8px) + branch icon width (18px), so the
+     subitem background starts exactly where the parent branch icon ends. */
+  margin: 0 2px 0 26px;
 }
 
 .branchTabItem {
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 6px 10px 6px 28px;
+  padding: 6px 10px 6px 8px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -540,6 +540,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   transition: background 0.1s;
+  background: none;
+  border: none;
+  font-family: inherit;
+  text-align: left;
+  width: 100%;
 }
 
 @media (hover: hover) {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -557,7 +557,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 6px 10px 6px 8px;
+  padding: 6px 10px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -533,8 +533,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 5px 10px 5px 28px;
-  margin: 1px 4px;
+  padding: 6px 10px 6px 28px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);
@@ -547,22 +546,22 @@
   border: none;
   font-family: inherit;
   text-align: left;
-  width: calc(100% - 8px);
+  width: 100%;
 }
 
 .branchTabItem.active {
-  background: rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.08);
   color: var(--fg-primary);
 }
 
 @media (hover: hover) {
   .branchTabItem:hover {
-    background: rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.08);
     color: var(--fg-primary);
   }
 
   .branchTabItem.active:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.11);
   }
 }
 

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -500,45 +500,40 @@
 }
 
 /* Branch tab list — collapsible terminal tab list under branch row */
-.branchTabsCountBadge {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 5px;
-  font-size: var(--font-2xs);
-  font-weight: 600;
-  font-family: var(--font-ui);
-  border-radius: var(--radius-pill);
-  white-space: nowrap;
-  flex-shrink: 0;
-  cursor: pointer;
+.branchTabsChevron {
+  background: none;
   border: none;
-  background: var(--bg-tertiary);
-  color: var(--fg-muted);
-  opacity: 0.7;
-  transition: background 0.1s, color 0.1s, opacity 0.1s;
-}
-
-.branchTabsCountBadge:hover {
-  opacity: 1;
-  background: var(--bg-highlight);
   color: var(--fg-secondary);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: transform 150ms ease, color 0.1s;
+  transform: rotate(0deg);
+  opacity: 0.75;
 }
 
-.branchTabsCountBadge.expanded {
-  background: var(--accent);
-  color: var(--text-on-accent);
+.branchTabsChevron:hover {
+  color: var(--fg-primary);
+  opacity: 1;
+}
+
+.branchTabsChevron.expanded {
+  transform: rotate(90deg);
+  color: var(--fg-primary);
   opacity: 1;
 }
 
 .branchTabList {
-  padding: 2px 0 2px 28px;
+  padding: 2px 0 4px 0;
 }
 
 .branchTabItem {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 3px 8px 3px 4px;
+  gap: 7px;
+  padding: 5px 8px 5px 30px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);
@@ -546,12 +541,17 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: background 0.1s;
+  transition: background 0.1s, color 0.1s;
   background: none;
   border: none;
   font-family: inherit;
   text-align: left;
   width: 100%;
+}
+
+.branchTabItem.active {
+  background: var(--bg-highlight);
+  color: var(--fg-primary);
 }
 
 @media (hover: hover) {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -557,7 +557,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 6px 10px;
+  padding: 6px 16px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -195,7 +195,7 @@
 }
 
 .repoChevron {
-  font-size: var(--font-lg);
+  font-size: var(--font-2xl);
   color: var(--fg-secondary);
   transition: transform 150ms ease;
   transform: rotate(0deg);
@@ -504,14 +504,14 @@
   background: none;
   border: none;
   color: var(--fg-secondary);
-  font-size: 14px;
+  font-size: var(--font-xl);
   cursor: pointer;
   padding: 0 2px;
   line-height: 1;
   flex-shrink: 0;
   transition: transform 150ms ease, color 0.1s;
   transform: rotate(0deg);
-  opacity: 0.75;
+  opacity: 0.8;
 }
 
 .branchTabsChevron:hover {
@@ -533,7 +533,8 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 5px 8px 5px 30px;
+  padding: 5px 10px 5px 28px;
+  margin: 1px 4px;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-sm);
@@ -541,23 +542,27 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: background 0.1s, color 0.1s;
+  transition: background 0.15s, color 0.15s;
   background: none;
   border: none;
   font-family: inherit;
   text-align: left;
-  width: 100%;
+  width: calc(100% - 8px);
 }
 
 .branchTabItem.active {
-  background: var(--bg-highlight);
+  background: rgba(255, 255, 255, 0.07);
   color: var(--fg-primary);
 }
 
 @media (hover: hover) {
   .branchTabItem:hover {
-    background: var(--bg-highlight);
+    background: rgba(255, 255, 255, 0.07);
     color: var(--fg-primary);
+  }
+
+  .branchTabItem.active:hover {
+    background: rgba(255, 255, 255, 0.1);
   }
 }
 

--- a/src/stores/repositories.ts
+++ b/src/stores/repositories.ts
@@ -376,6 +376,7 @@ function createRepositoriesStore() {
 					worktreePath: null,
 					terminals: [],
 					hadTerminals: false,
+					tabsExpanded: false,
 					lastActiveTerminal: null,
 					additions: 0,
 					deletions: 0,

--- a/src/stores/repositories.ts
+++ b/src/stores/repositories.ts
@@ -355,6 +355,13 @@ function createRepositoriesStore() {
 			save();
 		},
 
+		/** Set branch terminal tab list expanded state explicitly */
+		setBranchTabsExpanded(repoPath: string, branchName: string, expanded: boolean): void {
+			if (!state.repositories[repoPath]?.branches[branchName]) return;
+			setState("repositories", repoPath, "branches", branchName, "tabsExpanded", expanded);
+			save();
+		},
+
 		/** Update git repo status (used when a directory gains or loses .git) */
 		setIsGitRepo(path: string, isGitRepo: boolean): void {
 			setState("repositories", path, "isGitRepo", isGitRepo);

--- a/src/stores/repositories.ts
+++ b/src/stores/repositories.ts
@@ -40,6 +40,8 @@ export interface BranchState {
 	savedTerminals?: SavedTerminal[]; // Persisted terminal metadata for session restore
 	/** CI auto-heal: when enabled, CI failures trigger automatic agent fix cycles */
 	ciAutoHeal?: { enabled: boolean; attempts: number; lastRunId?: number; healing?: boolean };
+	/** Whether the terminal tab list is expanded under this branch row */
+	tabsExpanded?: boolean;
 }
 
 /** Repository with branches */
@@ -343,6 +345,13 @@ function createRepositoriesStore() {
 		/** Toggle repository collapsed state */
 		toggleCollapsed(path: string): void {
 			setState("repositories", path, "collapsed", (c) => !c);
+			save();
+		},
+
+		/** Toggle branch terminal tab list expanded state */
+		toggleBranchTabsExpanded(repoPath: string, branchName: string): void {
+			if (!state.repositories[repoPath]?.branches[branchName]) return;
+			setState("repositories", repoPath, "branches", branchName, "tabsExpanded", (e) => !e);
 			save();
 		},
 


### PR DESCRIPTION
## Summary

Adds a collapsible list of a branch's terminal tabs directly under each branch row in the left sidebar, so you can see and jump to a worktree's open terminals without opening the tab bar.

- New `tabsExpanded` flag on `BranchState`, persisted via `save_repositories` (same mechanism as sessions).
- `BranchTabList` renders one subitem per terminal — status dot (busy / idle / unseen / error / question) + terminal name. Clicking a subitem calls `navigateToTerminal` (switches branch context + focuses the terminal). Active terminal is highlighted.
- Subitems only appear when a branch has **more than one** terminal (single-terminal branches stay compact).
- Caret is a visual indicator; the whole branch row is the affordance:
  - Clicking an **unfocused** branch -> focuses it and **opens** the list (never collapses on a focus-switch).
  - Re-clicking the **already-focused** branch -> toggles (so it can be closed).
- Sub-level visual: list inset so its background starts where the parent branch icon ends; group-hover lifts the whole branch + tabs block as a unified card.

<img width="400" height="155" alt="tuitabs" src="https://github.com/user-attachments/assets/1d017073-48d4-4cf4-96dd-9b66193d3185" />

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green (4149 passed)
- [x] Store: toggleBranchTabsExpanded / setBranchTabsExpanded (toggle, set, idempotent open, no-op on unknown, debounced persist)
- [x] Component: chevron only with >1 terminal; one subitem per terminal when expanded; re-click active toggles; focus inactive opens (never toggles); single-terminal branch neither opens nor toggles
- [x] Manual: verify persistence across app restart, status-dot colors, and group-hover rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
