### PR TITLE
fix(worktree): suppress git checkout progress output with --quiet

### DIFF
--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -211,7 +211,9 @@ pub(crate) fn create_worktree_internal(
     // Build git worktree add command
     let base_repo_path = PathBuf::from(&config.base_repo);
     let wt_path_str = worktree_path.to_string_lossy().to_string();
-    let mut args: Vec<String> = vec!["worktree".into(), "add".into()];
+    // --quiet suppresses git's own checkout progress lines ("Updating files: X% (N/M)")
+    // that would otherwise appear in the controlling terminal. Hooks still run normally.
+    let mut args: Vec<String> = vec!["worktree".into(), "add".into(), "--quiet".into()];
 
     if config.create_branch
         && let Some(ref branch) = config.branch
@@ -256,6 +258,7 @@ pub(crate) fn create_worktree_internal(
                     let retry_args = [
                         "worktree",
                         "add",
+                        "--quiet",
                         &worktree_path.to_string_lossy(),
                         branch.as_str(),
                     ];
@@ -3024,6 +3027,37 @@ branch refs/heads/feat
 
         let base = get_branch_base(&repo.path().to_string_lossy(), "persist-base-test");
         assert_eq!(base, Some(default_branch));
+    }
+
+    // Verify that post-checkout hooks still run after `git worktree add --quiet`.
+    // --quiet only suppresses git's own checkout progress lines, not hooks.
+    #[test]
+    #[cfg(unix)]
+    fn test_create_worktree_runs_post_checkout_hook() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let repo = setup_test_repo();
+        let worktrees_dir = repo.path().join("worktrees");
+
+        let hooks_dir = repo.path().join(".git/hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let hook_path = hooks_dir.join("post-checkout");
+        fs::write(&hook_path, "#!/bin/sh\ntouch .hook-ran\n").unwrap();
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let config = WorktreeConfig {
+            task_name: "hook-run-test".to_string(),
+            base_repo: repo.path().to_string_lossy().to_string(),
+            branch: Some("hook-run-test".to_string()),
+            create_branch: true,
+        };
+        create_worktree_internal(&worktrees_dir, &config, None).unwrap();
+
+        let worktree_path = worktrees_dir.join("hook-run-test");
+        assert!(
+            worktree_path.join(".hook-ran").exists(),
+            "post-checkout hook did not run — --quiet must not suppress hooks"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What the bug looks like

When creating a worktree in a large repository, the terminal panel floods with individual lines of git checkout progress instead of updating in-place:

```
Updating files:   1% (  205/20529)
Updating files:   2% (  411/20529)
Updating files:   3% (  616/20529)
...
Updating files: 100% (20529/20529)
```

Each progress update creates a new scrollback line instead of overwriting the previous one.

## Screenshot
The issue is showing in the middle modal area. The left side red block is to hidden sensitive information

<img width="1189" height="800" alt="Captura de Tela 2026-06-18 às 11 45 22" src="https://github.com/user-attachments/assets/162f8c69-bf95-4c47-b3fd-cabf2cd7ac14" />


## Root cause

`git worktree add` emits checkout progress (`Updating files: X%`) to stderr or the controlling terminal. Even though TUICommander runs git as a subprocess with piped stdio (`Command::output()`), the progress can still reach the controlling terminal in certain environments (e.g. when the Tauri process is launched from a terminal, or when the process session has a TTY attached). Because the progress uses `\r` (carriage return) to overwrite in-place, and the TUICommander terminal panel processes `\r` as a new line in some states, every update creates a separate visible line.

## Fix

Pass `--quiet` to `git worktree add`. This flag tells git to suppress informational/progress output from the checkout phase. It is the standard way to silence this output in programmatic contexts.

**What `--quiet` does NOT affect:**
- The worktree is still fully created and checked out
- `post-checkout` hooks still run (pnpm install, nx build-deps, lefthook, etc.)
- Branch tracking and base-ref metadata are preserved

The flag is applied to both the initial call and the `BranchExists` retry path (the path taken when `git worktree add -b <branch>` fails because the branch already exists).

## Test

Added `test_create_worktree_runs_post_checkout_hook` (`#[cfg(unix)]`):

- Installs a real `post-checkout` hook that writes `.hook-ran` into the new worktree
- Calls `create_worktree_internal`
- Asserts `.hook-ran` **exists** — confirming `--quiet` does not suppress hook execution

```
cargo test test_create_worktree_runs_post_checkout_hook  # passes
```

## Checklist

- [x] `cargo test test_create_worktree_runs_post_checkout_hook` passes
- [x] All existing worktree tests pass (`cargo test test_create_worktree`)
- [x] Manually verified: creating a worktree in a large repo no longer floods the terminal panel
- [x] Post-checkout hooks still execute (pnpm install, nx build-deps, etc.)