### PR TITLE
feat(terminal): macOS Cmd editing keys (line start/end, kill line)

### DIFF
--- a/src/__tests__/components/CanvasTerminal-input.test.ts
+++ b/src/__tests__/components/CanvasTerminal-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	altSequenceFromCode,
+	cmdSequenceForKey,
 	createCompositionState,
 	DUP_KEYDOWN_WINDOW_MS,
 	keyToSequence,
@@ -160,6 +161,53 @@ describe("keyToSequence", () => {
 		expect(keyToSequence(evt("Alt"))).toBeNull();
 		expect(keyToSequence(evt("Meta"))).toBeNull();
 		expect(keyToSequence(evt("CapsLock"))).toBeNull();
+	});
+});
+
+describe("cmdSequenceForKey", () => {
+	const evt = (key: string, opts: Partial<KeyboardEvent> = {}): KeyboardEvent =>
+		({
+			key,
+			code: "",
+			ctrlKey: false,
+			altKey: false,
+			shiftKey: false,
+			metaKey: true,
+			...opts,
+		}) as unknown as KeyboardEvent;
+
+	it("maps Cmd+Left to beginning-of-line", () => {
+		expect(cmdSequenceForKey(evt("ArrowLeft"))).toBe("\x01");
+	});
+
+	it("maps Cmd+Right to end-of-line", () => {
+		expect(cmdSequenceForKey(evt("ArrowRight"))).toBe("\x05");
+	});
+
+	it("maps Cmd+Backspace to kill-to-line-start", () => {
+		expect(cmdSequenceForKey(evt("Backspace"))).toBe("\x15");
+	});
+
+	it("maps Cmd+Delete to kill-to-line-end", () => {
+		expect(cmdSequenceForKey(evt("Delete"))).toBe("\x0b");
+	});
+
+	it("ignores combos with extra modifiers so other handlers keep them", () => {
+		expect(cmdSequenceForKey(evt("ArrowLeft", { shiftKey: true }))).toBeNull();
+		expect(cmdSequenceForKey(evt("ArrowLeft", { altKey: true }))).toBeNull();
+		expect(cmdSequenceForKey(evt("ArrowLeft", { ctrlKey: true }))).toBeNull();
+	});
+
+	it("ignores non-editing Cmd keys (block nav, clipboard, app shortcuts)", () => {
+		expect(cmdSequenceForKey(evt("ArrowUp"))).toBeNull();
+		expect(cmdSequenceForKey(evt("ArrowDown"))).toBeNull();
+		expect(cmdSequenceForKey(evt("c"))).toBeNull();
+		expect(cmdSequenceForKey(evt("v"))).toBeNull();
+		expect(cmdSequenceForKey(evt("Enter"))).toBeNull();
+	});
+
+	it("returns null without the Cmd modifier", () => {
+		expect(cmdSequenceForKey(evt("ArrowLeft", { metaKey: false }))).toBeNull();
 	});
 });
 

--- a/src/components/Terminal/CanvasTerminal.tsx
+++ b/src/components/Terminal/CanvasTerminal.tsx
@@ -34,7 +34,7 @@ import { createGridRenderer, type GridRenderer } from "./gridRenderer";
 import { kittySequenceForKey } from "./kittyKeyboard";
 import { filePathRegex, fileUrlRegex } from "./linkProvider";
 import { continuationRowsAfterSuggest, isSuggestBlock } from "./suggestOverlay";
-import { altSequenceFromCode, createCompositionState, keyToSequence } from "./terminalInput";
+import { altSequenceFromCode, cmdSequenceForKey, createCompositionState, keyToSequence } from "./terminalInput";
 
 // Re-export for external consumers
 export type { CellMetrics, CursorShape, DecodedFrame };
@@ -2304,6 +2304,18 @@ const CanvasTerminal: Component<CanvasTerminalProps> = (props) => {
 					const ctrl = String.fromCharCode(cm[1].charCodeAt(0) - 0x40);
 					e.preventDefault();
 					writePty(ctrl);
+					return;
+				}
+			}
+
+			// macOS Cmd editing keys: Cmd+Left/Right → line start/end,
+			// Cmd+Backspace/Delete → kill to line start/end. Cmd+Up/Down
+			// (block nav) and Cmd+C/V (clipboard) are handled above.
+			if (isMacOS()) {
+				const cmdSeq = cmdSequenceForKey(e);
+				if (cmdSeq !== null) {
+					e.preventDefault();
+					writePty(cmdSeq);
 					return;
 				}
 			}

--- a/src/components/Terminal/terminalInput.ts
+++ b/src/components/Terminal/terminalInput.ts
@@ -251,3 +251,26 @@ export function altSequenceFromCode(e: KeyboardEvent): string | null {
 
 	return null;
 }
+
+/**
+ * macOS Cmd editing keys (iTerm2 "Natural Text Editing" convention):
+ * Cmd+Left/Right jump to line start/end, Cmd+Backspace kills to line start,
+ * Cmd+Delete kills to line end. Readline control codes work in shells and TUI
+ * prompts alike. Returns null for every other combo so Cmd+Up/Down block
+ * navigation, Cmd+C/V clipboard, and app shortcuts stay untouched.
+ */
+export function cmdSequenceForKey(e: KeyboardEvent): string | null {
+	if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return null;
+	switch (e.key) {
+		case "ArrowLeft":
+			return "\x01"; // beginning-of-line
+		case "ArrowRight":
+			return "\x05"; // end-of-line
+		case "Backspace":
+			return "\x15"; // kill to line start
+		case "Delete":
+			return "\x0b"; // kill to line end
+		default:
+			return null;
+	}
+}

--- a/to-test.md
+++ b/to-test.md
@@ -10,6 +10,12 @@
 
 Features to test when TUICommander is more usable.
 
+## macOS Cmd editing keys in terminal (2026-07-11)
+
+- [HUMAN] In a plain zsh terminal type a long command, then: Cmd+Left → cursor jumps to line start (`\x01`), Cmd+Right → line end (`\x05`), Cmd+Backspace → deletes to line start (`\x15`), Cmd+Delete → deletes to line end (`\x0b`). (`terminalInput.ts` `cmdSequenceForKey`, wired in `CanvasTerminal.tsx`.)
+- [HUMAN] Same four chords inside Claude Code's input box — line start/end jump and kill-to-start/end must work (readline control codes).
+- [HUMAN] Verify no regressions on nearby chords: Cmd+Up/Down still jumps between command blocks, Cmd+C still copies a selection, Cmd+Shift+Left/Right does nothing new (falls through), Option+Left/Right still word-jumps.
+
 ## Clipboard "Copy Path" fix (2026-07-02, uncommitted)
 
 - [ ] **Copy Path / copy actions in all context menus** now route through the native clipboard-manager plugin (`writeClipboard`) instead of `navigator.clipboard.writeText` (rejected by WKWebView). Verify paste works after: RepoSection branch/worktree Copy Path, TabBar (diff/markdown/editor) Copy Path, FileBrowser Copy Path, CodeEditorTab, MarkdownPanel/Tab, StatusBar cwd, App "Copy Block Output", ErrorLogPanel, GeneratorsModal, AIChatPanel, GitHubPanel/Tab, ServicesTab, KnowledgeHistory, useSmartPrompts clipboard output.


### PR DESCRIPTION
## Summary

On macOS, the standard Cmd editing chords do nothing in the terminal — `keyToSequence` returns `null` for any `metaKey` press, so the keys are silently dropped. This adds the iTerm2 "Natural Text Editing" convention (same bytes VS Code's and Superset's terminals send):

| Chord | Sequence | Effect |
|---|---|---|
| Cmd+Left | `\x01` | jump to line start |
| Cmd+Right | `\x05` | jump to line end |
| Cmd+Backspace | `\x15` | delete to line start |
| Cmd+Delete | `\x0b` | delete to line end |

- Implemented as a pure `cmdSequenceForKey()` in `terminalInput.ts` (unit-testable), wired into the CanvasTerminal keydown path after the Ctrl+letter block.
- Any extra modifier returns `null`, so Cmd+Up/Down block navigation, Cmd+C/V clipboard handling, Cmd+Enter, and app shortcuts are untouched. Option+Left/Right/Backspace word operations already existed and are unchanged.
- Readline control codes work in shells (bash/zsh emacs mode) and TUI prompts (Claude Code, Ink) alike.

## Test plan

- `pnpm exec vitest run src/__tests__/components/CanvasTerminal-input.test.ts` — 7 new tests for the four chords, modifier guards, and pass-through combos (72 total green)
- `tsc --noEmit` and `biome check` clean; frontend-only change, no Rust impact
- Manual entries added to `to-test.md` (plain zsh + Claude Code + no-regression chords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)