### PR TITLE
fix(notes-panel): ignore Enter key during IME composition

### DIFF
--- a/src/__tests__/components/NotesPanel.test.tsx
+++ b/src/__tests__/components/NotesPanel.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockInvoke } = vi.hoisted(() => {
+	return { mockInvoke: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: mockInvoke,
+	convertFileSrc: (path: string) => path,
+}));
+
+vi.mock("../../invoke", () => ({
+	invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { NotesPanel } from "../../components/NotesPanel/NotesPanel";
+import { notesStore } from "../../stores/notes";
+
+const noop = () => {};
+
+function renderPanel() {
+	return render(() => <NotesPanel visible={true} repoPath={null} onClose={noop} onSendToTerminal={noop} />);
+}
+
+describe("NotesPanel — IME composition handling", () => {
+	beforeEach(() => {
+		for (const note of [...notesStore.state.notes]) {
+			notesStore.removeNote(note.id);
+		}
+		mockInvoke.mockClear();
+	});
+
+	it("does not submit when Enter is pressed during IME composition (isComposing=true)", () => {
+		const { container } = renderPanel();
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+		fireEvent.input(textarea, { target: { value: "ねこ" } });
+		fireEvent.keyDown(textarea, { key: "Enter", isComposing: true, keyCode: 229 });
+
+		expect(notesStore.state.notes.length).toBe(0);
+		expect(textarea.value).toBe("ねこ");
+	});
+
+	it("does not submit on the IME-confirming Enter even when isComposing has already flipped to false (WebKit quirk)", () => {
+		const { container } = renderPanel();
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+		fireEvent.input(textarea, { target: { value: "猫" } });
+		fireEvent.keyDown(textarea, { key: "Enter", isComposing: false, keyCode: 229 });
+
+		expect(notesStore.state.notes.length).toBe(0);
+		expect(textarea.value).toBe("猫");
+	});
+
+	it("submits normally on a real Enter press (not IME)", () => {
+		const { container } = renderPanel();
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+		fireEvent.input(textarea, { target: { value: "hello world" } });
+		fireEvent.keyDown(textarea, { key: "Enter", isComposing: false, keyCode: 13 });
+
+		expect(notesStore.state.notes.length).toBe(1);
+		expect(notesStore.state.notes[0].text).toBe("hello world");
+	});
+
+	it("still inserts a newline on Shift+Enter without submitting", () => {
+		const { container } = renderPanel();
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+		fireEvent.input(textarea, { target: { value: "line one" } });
+		fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true, isComposing: false, keyCode: 13 });
+
+		expect(notesStore.state.notes.length).toBe(0);
+	});
+});

--- a/src/components/NotesPanel/NotesPanel.tsx
+++ b/src/components/NotesPanel/NotesPanel.tsx
@@ -160,7 +160,11 @@ export const NotesPanel: Component<NotesPanelProps> = (props) => {
 	};
 
 	const handleKeyDown = (e: KeyboardEvent) => {
-		if (e.key === "Enter" && !e.shiftKey) {
+		if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
+			// keyCode 229 = IME composition in progress or just confirmed.
+			// WebKit (Safari/Tauri on macOS) sets isComposing=false on the
+			// confirming Enter keydown before keyup, so isComposing alone
+			// isn't reliable here — keyCode is the fallback signal.
 			e.preventDefault();
 			handleSubmit();
 		}


### PR DESCRIPTION
## Summary

Fixes an issue where the Ideas (Notes) panel textarea would submit the
current input as soon as Enter was pressed to confirm an IME conversion
(e.g. Japanese, Chinese, Korean input), instead of only confirming the
composition. This made it effectively impossible to type CJK text
normally in this field.

The straightforward fix — checking `event.isComposing` in the Enter key
handler — was not sufficient on WebKit (Safari / Tauri on macOS): WebKit
sets `isComposing` to `false` on the very keydown event that confirms the
IME composition, before the corresponding `compositionend` fires. This
means `isComposing` alone can't distinguish "the Enter that confirms
composition" from "a real Enter press" on this engine.

Confirmed via manual logging (`key`, `isComposing`, `keyCode` on every
keydown while typing "ねこ" → "猫" and confirming) that on the
confirming Enter, WebKit reports `isComposing: false` but
`keyCode: 229`. `keyCode === 229` is a long-standing (if technically
deprecated) signal specifically used to detect IME composition state,
and is checked here as a fallback alongside `isComposing` to cover both
browser behaviors.

## Changes

- `src/components/NotesPanel/NotesPanel.tsx`: `handleKeyDown` now also
  checks `event.keyCode !== 229` in addition to `!event.isComposing`
  before treating Enter as a submit action. `Escape` (cancel edit)
  behavior is unchanged.
- `src/__tests__/components/NotesPanel.test.tsx` (new): component-level
  regression tests for the Enter/IME interaction, using
  `@solidjs/testing-library`.


## Test Plan

### Automated

Added `src/__tests__/components/NotesPanel.test.tsx` with 4 cases:

- does not submit when Enter is pressed during IME composition
  (`isComposing: true`)
- does not submit on the IME-confirming Enter even when `isComposing`
  has already flipped to `false` (the WebKit quirk this PR specifically
  fixes — `isComposing: false`, `keyCode: 229`)
- submits normally on a real Enter press (not IME)
- Shift+Enter still inserts a newline without submitting

Verified the new tests fail without the fix (reverted the one-line
change locally, confirmed the two composition-related tests fail with
the exact symptom this PR addresses, i.e. the note gets submitted when
it shouldn't) and pass with it.

```bash
pnpm exec vitest run NotesPanel.test.tsx
```

### Manual

Verified on macOS (Tauri / WKWebView) with the Japanese IME:
typed a word requiring conversion (e.g. "ねこ" → "猫"), pressed Enter to
confirm — text is now correctly committed into the textarea instead of
being submitted. A second Enter press submits normally.

### Full suite

```bash
pnpm exec tsc --noEmit        # exit 0
pnpm exec vitest run          # 4626 passed, 1 pre-existing failure (see note below)
cd src-tauri && cargo test    # 3915 passed, 1 pre-existing failure (see note below)
```

**Pre-existing failures, unrelated to this change** (confirmed present
on `main` without this branch's changes):

- `buildCleaner.test.ts` fails to resolve
  `../../../plugins/build-cleaner/main.js` — appears to be a missing
  local file/submodule, not something introduced here.
- `cli::tests::test_resolve_cli_finds_known_binary` fails locally with
  `resolve_cli('git') should return an absolute path, got: git` —
  environment-dependent (likely PATH/shim resolution for `git` on this
  machine), also reproduces on `main`.

No Rust code was touched in this PR.