### PR TITLE
fix(test): normalize UTC date rendering in shootout_commit_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **Tests: `shootout_commit_log` no longer depends on the git CLI's UTC date spelling** — gix renders `+00:00`, git ≤2.34 renders `Z`; the differential test now normalizes the equivalent spellings before comparing.
 
 - **Awaiting-input state is turn-scoped and transport-consistent** — Historical questions no longer re-arm after a later response or completion, bare Enter clears waits through desktop and HTTP input alike, and an open MCP UI confirmation no longer blocks other agents' requests.
 - **Agent state transitions cannot be dropped by a busy event consumer** — Sticky per-session state now uses a lossless reducer lane instead of depending on the best-effort broadcast bus, preserves every response-required OSC notification in a PTY chunk, keeps an unobserved shell in `starting`, and recognizes a non-empty input box above arbitrarily tall custom HUDs.

--- a/src-tauri/src/git_reads.rs
+++ b/src-tauri/src/git_reads.rs
@@ -1506,7 +1506,23 @@ mod tests {
         let cli = CliGitReads;
         let gix = GixGitReads::new();
 
-        let json = |v: &Vec<CommitLogEntry>| serde_json::to_value(v).unwrap();
+        // Compare date IDENTITY, not rendering: git-cli's ISO output spells
+        // UTC as `Z` on some versions (e.g. 2.34) and `+00:00` on others,
+        // while gix always renders `+00:00`. Same instant, two legal ISO-8601
+        // spellings — normalize to `Z` before comparing.
+        let json = |v: &Vec<CommitLogEntry>| {
+            let mut val = serde_json::to_value(v).unwrap();
+            if let serde_json::Value::Array(items) = &mut val {
+                for item in items {
+                    if let Some(serde_json::Value::String(d)) = item.get_mut("author_date") {
+                        if let Some(stripped) = d.strip_suffix("+00:00") {
+                            *d = format!("{stripped}Z");
+                        }
+                    }
+                }
+            }
+            val
+        };
         let a = cli.commit_log(&repo, None, None).unwrap();
         let b = gix.commit_log(&repo, None, None).unwrap();
         assert_eq!(json(&a), json(&b), "commit_log gix != cli");


### PR DESCRIPTION
## Summary

- `shootout_commit_log` checks that the two git backends (the `gix` library and the `git` CLI) report the same commit history. It compares their output byte-for-byte.
- The two backends write the same UTC timestamp two different ways. `gix` writes `+00:00`. The git CLI writes `Z` on some versions — stock Ubuntu 22.04 ships git 2.34.1, which does. Both spellings mean the same instant.
- Result: on a plain Ubuntu 22.04 machine, a fresh clone of `main` fails its own test suite, even though both backends agree on every hash, parent, ref, and subject.
- The fix: normalize the two spellings of UTC to one form before the compare. Everything else stays byte-for-byte. This is the same compare-the-fact-not-the-rendering approach the `worktree_paths` test in this file already uses for path spellings.
- Files touched: one test function in `src-tauri/src/git_reads.rs`, plus a `CHANGELOG.md` entry.
- The normalization cannot hide a real bug: only the two spellings of a zero UTC offset are unified. If the backends ever disagree on the actual time, the test still fails.

## Test plan

- [x] **Reproduced the bug, then proved the fix** on Ubuntu 22.04 / git 2.34.1: the test fails before this change and passes after it. The changed test is itself the regression instrument — fails-without / passes-with.
- [x] **Full Rust suite on Ubuntu 22.04 (git 2.34.1):** `cargo nextest run` — 4348 run, **4348 passed, 0 failed**, 10 skipped. The 10 skips are the suite's own `#[ignore]` tests, marked by the maintainer (interactive keyring, network + GitHub token, explicit perf run, PTY capture fixtures) — untouched by this change and skipped identically on every platform.
- [x] **`git_reads` module focused run:** 15/15 pass on the same environment.
- [x] **`cargo clippy -- -D warnings`** — clean.
- [x] **`pnpm exec tsc --noEmit`** — clean.
- [x] **`pnpm exec vitest run`** — no change from `main`: this diff touches zero frontend files, and the frontend result on this branch is byte-identical to `main`'s on the same machine (verified side by side).
- [x] **No-op where CI already passed:** on newer git, both backends already spell UTC the same way, so the normalization changes nothing there — CI's green stays green.

## Blast radius

- One test function inside a `#[cfg(test)]` module; production code untouched.
- Worst plausible regression: the normalization masks a real date disagreement. It cannot — only `+00:00` → `Z` at a zero offset is unified; any differing instant still fails the compare.

---

*AI-assisted change; reviewed, verified, and submitted under my own accountability.*
