### PR TITLE
feat(worktree): add a setting to turn off the switch-to-new-worktree prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **The "Switch to new worktree?" dialog can be turned off** (Settings, GitHub tab, Worktree Defaults, "Ask to switch after creating a worktree", with a per-repo override on the repository's Worktree tab). Only backend-initiated creations raise that dialog: `worktree-created` is emitted by the MCP `repo worktree_create` tool and the HTTP worktree route, never by the in-app "+" button. An orchestrating agent that creates a worktree every few minutes therefore asks a question nobody is at the keyboard to answer, and each one waits out its ten-second auto-cancel. The setting defaults to on, so nothing changes until you turn it off. The sidebar row and the Activity entry for the new worktree are added either way.
+
 ## [1.7.5] - 2026-08-27
 
 ### Fixed

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -173,7 +173,7 @@ A `.tuic.json` file in the repository root provides team-shareable settings that
 
 Supported fields: `base_branch`, `copy_ignored_files`, `copy_untracked_files`, `setup_script`, `run_script`, `archive_script`, `worktree_storage`, `delete_branch_on_remove`, `auto_archive_merged`, `orphan_cleanup`, `pr_merge_strategy`, `after_merge`, `auto_delete_on_pr_close`.
 
-User-specific settings (`promptOnCreate`, `autoFetchIntervalMinutes`) are intentionally excluded from `.tuic.json`.
+User-specific settings (`promptOnCreate`, `promptOnWorktreeSwitch`, `autoFetchIntervalMinutes`) are intentionally excluded from `.tuic.json`.
 
 ## Notification Settings
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1060,6 +1060,8 @@ pub(crate) struct RepoSettingsEntry {
     #[serde(default)]
     pub(crate) prompt_on_create: Option<bool>,
     #[serde(default)]
+    pub(crate) prompt_on_worktree_switch: Option<bool>,
+    #[serde(default)]
     pub(crate) delete_branch_on_remove: Option<bool>,
     #[serde(default)]
     pub(crate) auto_archive_merged: Option<bool>,
@@ -1100,6 +1102,7 @@ impl RepoSettingsEntry {
             || !self.color.is_empty()
             || self.worktree_storage.is_some()
             || self.prompt_on_create.is_some()
+            || self.prompt_on_worktree_switch.is_some()
             || self.delete_branch_on_remove.is_some()
             || self.auto_archive_merged.is_some()
             || self.orphan_cleanup.is_some()
@@ -1133,6 +1136,9 @@ pub(crate) struct RepoDefaultsConfig {
     pub(crate) worktree_storage: WorktreeStorage,
     #[serde(default = "default_true")]
     pub(crate) prompt_on_create: bool,
+    /// Ask whether to switch to a worktree the backend just created
+    #[serde(default = "default_true")]
+    pub(crate) prompt_on_worktree_switch: bool,
     #[serde(default = "default_true")]
     pub(crate) delete_branch_on_remove: bool,
     #[serde(default)]
@@ -1162,6 +1168,7 @@ impl Default for RepoDefaultsConfig {
             archive_script: String::new(),
             worktree_storage: WorktreeStorage::default(),
             prompt_on_create: true,
+            prompt_on_worktree_switch: true,
             delete_branch_on_remove: true,
             auto_archive_merged: false,
             orphan_cleanup: OrphanCleanup::default(),
@@ -3553,6 +3560,7 @@ mod tests {
                 color: String::new(),
                 worktree_storage: None,
                 prompt_on_create: None,
+                prompt_on_worktree_switch: None,
                 delete_branch_on_remove: None,
                 auto_archive_merged: None,
                 orphan_cleanup: None,
@@ -4032,6 +4040,7 @@ mod tests {
         let cfg = RepoDefaultsConfig {
             worktree_storage: WorktreeStorage::InsideRepo,
             prompt_on_create: false,
+            prompt_on_worktree_switch: false,
             delete_branch_on_remove: false,
             auto_archive_merged: true,
             orphan_cleanup: OrphanCleanup::On,
@@ -4043,6 +4052,7 @@ mod tests {
         let loaded: RepoDefaultsConfig = round_trip_in_dir(dir.path(), "repo-defaults.json", &cfg);
         assert_eq!(loaded.worktree_storage, WorktreeStorage::InsideRepo);
         assert!(!loaded.prompt_on_create);
+        assert!(!loaded.prompt_on_worktree_switch);
         assert!(!loaded.delete_branch_on_remove);
         assert!(loaded.auto_archive_merged);
         assert_eq!(loaded.orphan_cleanup, OrphanCleanup::On);
@@ -4058,6 +4068,7 @@ mod tests {
         let loaded: RepoDefaultsConfig = serde_json::from_str(json).unwrap();
         assert_eq!(loaded.worktree_storage, WorktreeStorage::Sibling);
         assert!(loaded.prompt_on_create);
+        assert!(loaded.prompt_on_worktree_switch);
         assert!(loaded.delete_branch_on_remove);
         assert!(!loaded.auto_archive_merged);
         assert_eq!(loaded.orphan_cleanup, OrphanCleanup::Ask);
@@ -4077,6 +4088,7 @@ mod tests {
                 path: "/my/repo".to_string(),
                 worktree_storage: Some(WorktreeStorage::AppDir),
                 prompt_on_create: Some(false),
+                prompt_on_worktree_switch: Some(false),
                 delete_branch_on_remove: Some(false),
                 auto_archive_merged: Some(true),
                 orphan_cleanup: Some(OrphanCleanup::Off),
@@ -4090,6 +4102,7 @@ mod tests {
         let entry = loaded.repos.get("/my/repo").unwrap();
         assert_eq!(entry.worktree_storage, Some(WorktreeStorage::AppDir));
         assert_eq!(entry.prompt_on_create, Some(false));
+        assert_eq!(entry.prompt_on_worktree_switch, Some(false));
         assert_eq!(entry.delete_branch_on_remove, Some(false));
         assert_eq!(entry.auto_archive_merged, Some(true));
         assert_eq!(entry.orphan_cleanup, Some(OrphanCleanup::Off));
@@ -4108,6 +4121,7 @@ mod tests {
         let entry: RepoSettingsEntry = serde_json::from_str(json).unwrap();
         assert_eq!(entry.worktree_storage, None);
         assert_eq!(entry.prompt_on_create, None);
+        assert_eq!(entry.prompt_on_worktree_switch, None);
         assert_eq!(entry.delete_branch_on_remove, None);
         assert_eq!(entry.orphan_cleanup, None);
     }
@@ -4125,6 +4139,15 @@ mod tests {
     fn has_custom_settings_true_when_prompt_on_create_set() {
         let entry = RepoSettingsEntry {
             prompt_on_create: Some(false),
+            ..RepoSettingsEntry::default()
+        };
+        assert!(entry.has_custom_settings());
+    }
+
+    #[test]
+    fn has_custom_settings_true_when_prompt_on_worktree_switch_set() {
+        let entry = RepoSettingsEntry {
+            prompt_on_worktree_switch: Some(false),
             ..RepoSettingsEntry::default()
         };
         assert!(entry.has_custom_settings());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,6 +399,10 @@ const App: Component = () => {
 		confirm: (opts) => dialogs.confirm(opts),
 		handleBranchSelect: gitOps.handleBranchSelect,
 		closeTerminalsForBranch: gitOps.closeTerminalsForBranch,
+		getPromptOnWorktreeSwitch: (repoPath: string) => {
+			const effective = repoSettingsStore.getEffective(repoPath);
+			return effective?.promptOnWorktreeSwitch ?? repoDefaultsStore.state.promptOnWorktreeSwitch;
+		},
 	});
 
 	// Register built-in activity sections for git and worktree notifications

--- a/src/__tests__/components/RepoSettingsPanel.test.tsx
+++ b/src/__tests__/components/RepoSettingsPanel.test.tsx
@@ -103,6 +103,7 @@ describe("SettingsPanel — repo context", () => {
 			terminalMetaHotkeys: null,
 			worktreeStorage: null,
 			promptOnCreate: null,
+			promptOnWorktreeSwitch: null,
 			deleteBranchOnRemove: null,
 			autoArchiveMerged: null,
 			orphanCleanup: null,

--- a/src/__tests__/hooks/worktreeSwitchPrompt.test.ts
+++ b/src/__tests__/hooks/worktreeSwitchPrompt.test.ts
@@ -97,6 +97,54 @@ describe("promptForCreatedWorktree", () => {
 		});
 	});
 
+	it("skips the prompt entirely when promptOnWorktreeSwitch is off for the repo", async () => {
+		await testInScopeAsync(async () => {
+			const terminalId = seedActiveTerminal(null);
+			const confirm = vi.fn().mockResolvedValue(true);
+			const handleBranchSelect = vi.fn().mockResolvedValue(undefined);
+
+			await promptForCreatedWorktree(
+				{
+					confirm,
+					handleBranchSelect,
+					closeTerminalsForBranch: vi.fn(),
+					getPromptOnWorktreeSwitch: () => false,
+				},
+				REPO,
+				BRANCH,
+				WORKTREE,
+			);
+
+			expect(confirm).not.toHaveBeenCalled();
+			expect(handleBranchSelect).not.toHaveBeenCalled();
+			expect(repositoriesStore.get(REPO)!.branches.main.terminals).toContain(terminalId);
+			expect(mockInvoke).not.toHaveBeenCalled();
+		});
+	});
+
+	it("still asks when promptOnWorktreeSwitch is on for the repo", async () => {
+		await testInScopeAsync(async () => {
+			seedActiveTerminal(null);
+			const confirm = vi.fn().mockResolvedValue(true);
+			const handleBranchSelect = vi.fn().mockResolvedValue(undefined);
+
+			await promptForCreatedWorktree(
+				{
+					confirm,
+					handleBranchSelect,
+					closeTerminalsForBranch: vi.fn(),
+					getPromptOnWorktreeSwitch: () => true,
+				},
+				REPO,
+				BRANCH,
+				WORKTREE,
+			);
+
+			expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Switch to new worktree?" }));
+			expect(handleBranchSelect).toHaveBeenCalledWith(REPO, BRANCH);
+		});
+	});
+
 	it("keeps moving a plain shell into the worktree", async () => {
 		await testInScopeAsync(async () => {
 			const terminalId = seedActiveTerminal(null);

--- a/src/__tests__/stores/repoDefaults.test.ts
+++ b/src/__tests__/stores/repoDefaults.test.ts
@@ -54,6 +54,26 @@ describe("repoDefaultsStore", () => {
 			});
 		});
 
+		it("defaults promptOnWorktreeSwitch to true when the key is absent", async () => {
+			mockInvoke.mockResolvedValueOnce({ base_branch: "main" });
+
+			await store.hydrate();
+
+			testInScope(() => {
+				expect(store.state.promptOnWorktreeSwitch).toBe(true);
+			});
+		});
+
+		it("loads an explicit promptOnWorktreeSwitch of false", async () => {
+			mockInvoke.mockResolvedValueOnce({ prompt_on_worktree_switch: false });
+
+			await store.hydrate();
+
+			testInScope(() => {
+				expect(store.state.promptOnWorktreeSwitch).toBe(false);
+			});
+		});
+
 		it("keeps defaults when backend returns null", async () => {
 			mockInvoke.mockResolvedValueOnce(null);
 			await store.hydrate();
@@ -83,6 +103,19 @@ describe("repoDefaultsStore", () => {
 					"save_repo_defaults",
 					expect.objectContaining({
 						config: expect.objectContaining({ base_branch: "main" }),
+					}),
+				);
+			});
+		});
+
+		it("setPromptOnWorktreeSwitch updates state and persists", () => {
+			testInScope(() => {
+				store.setPromptOnWorktreeSwitch(false);
+				expect(store.state.promptOnWorktreeSwitch).toBe(false);
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"save_repo_defaults",
+					expect.objectContaining({
+						config: expect.objectContaining({ prompt_on_worktree_switch: false }),
 					}),
 				);
 			});
@@ -148,6 +181,7 @@ describe("repoDefaultsStore", () => {
 						archive_script: "",
 						worktree_storage: "sibling",
 						prompt_on_create: true,
+						prompt_on_worktree_switch: true,
 						delete_branch_on_remove: true,
 						auto_archive_merged: false,
 						orphan_cleanup: "ask",

--- a/src/components/SettingsPanel/tabs/GitHubTab.tsx
+++ b/src/components/SettingsPanel/tabs/GitHubTab.tsx
@@ -706,6 +706,13 @@ export const GitHubTab: Component = () => {
 				/>
 
 				<SettingToggle
+					checked={repoDefaultsStore.state.promptOnWorktreeSwitch}
+					onChange={(v) => repoDefaultsStore.setPromptOnWorktreeSwitch(v)}
+					label="Ask to switch after creating a worktree"
+					hint="Show the 'Switch to new worktree?' dialog when an agent creates a worktree over MCP or the HTTP API. Turn off during parallel agent runs"
+				/>
+
+				<SettingToggle
 					checked={repoDefaultsStore.state.deleteBranchOnRemove}
 					onChange={(v) => repoDefaultsStore.setDeleteBranchOnRemove(v)}
 					label="Delete local branch when removing worktree"

--- a/src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx
+++ b/src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx
@@ -220,6 +220,22 @@ export const RepoWorktreeTab: Component<RepoTabProps> = (props) => {
 				<div class={s.toggle}>
 					<input
 						type="checkbox"
+						checked={effectiveBool(props.settings.promptOnWorktreeSwitch, props.defaults.promptOnWorktreeSwitch)}
+						onChange={(e) => props.onUpdate("promptOnWorktreeSwitch", e.currentTarget.checked)}
+					/>
+					<span>
+						{t("repoWorktree.toggle.promptOnWorktreeSwitch", "Ask to switch after creating a worktree")}
+						<Show when={props.settings.promptOnWorktreeSwitch === null}>
+							<span class={s.hintInline}> {t("repoWorktree.hint.globalDefault", "(Global Default)")}</span>
+						</Show>
+					</span>
+				</div>
+			</div>
+
+			<div class={s.group}>
+				<div class={s.toggle}>
+					<input
+						type="checkbox"
 						checked={effectiveBool(props.settings.deleteBranchOnRemove, props.defaults.deleteBranchOnRemove)}
 						onChange={(e) => props.onUpdate("deleteBranchOnRemove", e.currentTarget.checked)}
 					/>

--- a/src/hooks/useWorktreeSwitchPrompt.ts
+++ b/src/hooks/useWorktreeSwitchPrompt.ts
@@ -10,6 +10,10 @@ interface WorktreeSwitchDeps {
 	confirm: (options: ConfirmOptions) => Promise<boolean>;
 	handleBranchSelect: (repoPath: string, branchName: string) => Promise<void>;
 	closeTerminalsForBranch: (repoPath: string, branchName: string) => Promise<void>;
+	/** Returns the effective promptOnWorktreeSwitch setting for the given repo.
+	 *  When false, a created worktree is registered in the sidebar without asking.
+	 *  Defaults to true (ask) when not provided. */
+	getPromptOnWorktreeSwitch?: (repoPath: string) => boolean;
 }
 
 interface WorktreeCreatedPayload {
@@ -27,6 +31,11 @@ interface WorktreeRemovedPayload {
  * Offer the newly created worktree without pretending a running agent can move
  * with its terminal. Branch selection opens or focuses a terminal rooted in the
  * worktree; the agent terminal remains attached to its original branch and CWD.
+ *
+ * Only backend-initiated creations reach here (MCP, HTTP), so an orchestrating
+ * agent creating a worktree every few minutes asks a question nobody is at the
+ * keyboard to answer. `promptOnWorktreeSwitch` turns the question off; the
+ * sidebar row and activity entry are added by the caller either way.
  */
 export async function promptForCreatedWorktree(
 	deps: WorktreeSwitchDeps,
@@ -34,6 +43,8 @@ export async function promptForCreatedWorktree(
 	branch: string,
 	worktreePath: string,
 ): Promise<void> {
+	if (deps.getPromptOnWorktreeSwitch?.(repoPath) === false) return;
+
 	const activeTerm = terminalsStore.getActive();
 	const isAgentRunning = activeTerm?.agentType != null;
 

--- a/src/stores/repoDefaults.ts
+++ b/src/stores/repoDefaults.ts
@@ -27,6 +27,7 @@ export interface RepoDefaults {
 	archiveScript: string;
 	worktreeStorage: WorktreeStorage;
 	promptOnCreate: boolean;
+	promptOnWorktreeSwitch: boolean;
 	deleteBranchOnRemove: boolean;
 	autoArchiveMerged: boolean;
 	orphanCleanup: OrphanCleanup;
@@ -45,6 +46,7 @@ const INITIAL_DEFAULTS: RepoDefaults = {
 	archiveScript: "",
 	worktreeStorage: "sibling",
 	promptOnCreate: true,
+	promptOnWorktreeSwitch: true,
 	deleteBranchOnRemove: true,
 	autoArchiveMerged: false,
 	orphanCleanup: "ask",
@@ -68,6 +70,7 @@ function createRepoDefaultsStore() {
 				archive_script: state.archiveScript,
 				worktree_storage: state.worktreeStorage,
 				prompt_on_create: state.promptOnCreate,
+				prompt_on_worktree_switch: state.promptOnWorktreeSwitch,
 				delete_branch_on_remove: state.deleteBranchOnRemove,
 				auto_archive_merged: state.autoArchiveMerged,
 				orphan_cleanup: state.orphanCleanup,
@@ -93,6 +96,7 @@ function createRepoDefaultsStore() {
 					archive_script?: string;
 					worktree_storage?: WorktreeStorage;
 					prompt_on_create?: boolean;
+					prompt_on_worktree_switch?: boolean;
 					delete_branch_on_remove?: boolean;
 					auto_archive_merged?: boolean;
 					orphan_cleanup?: OrphanCleanup;
@@ -111,6 +115,7 @@ function createRepoDefaultsStore() {
 						archiveScript: loaded.archive_script ?? INITIAL_DEFAULTS.archiveScript,
 						worktreeStorage: loaded.worktree_storage ?? INITIAL_DEFAULTS.worktreeStorage,
 						promptOnCreate: loaded.prompt_on_create ?? INITIAL_DEFAULTS.promptOnCreate,
+						promptOnWorktreeSwitch: loaded.prompt_on_worktree_switch ?? INITIAL_DEFAULTS.promptOnWorktreeSwitch,
 						deleteBranchOnRemove: loaded.delete_branch_on_remove ?? INITIAL_DEFAULTS.deleteBranchOnRemove,
 						autoArchiveMerged: loaded.auto_archive_merged ?? INITIAL_DEFAULTS.autoArchiveMerged,
 						orphanCleanup: loaded.orphan_cleanup ?? INITIAL_DEFAULTS.orphanCleanup,
@@ -162,6 +167,11 @@ function createRepoDefaultsStore() {
 
 		setPromptOnCreate(value: boolean): void {
 			setState("promptOnCreate", value);
+			save();
+		},
+
+		setPromptOnWorktreeSwitch(value: boolean): void {
+			setState("promptOnWorktreeSwitch", value);
 			save();
 		},
 

--- a/src/stores/repoSettings.ts
+++ b/src/stores/repoSettings.ts
@@ -39,6 +39,8 @@ export interface RepoSettings {
 	/** null = inherit from repoDefaultsStore */
 	promptOnCreate: boolean | null;
 	/** null = inherit from repoDefaultsStore */
+	promptOnWorktreeSwitch: boolean | null;
+	/** null = inherit from repoDefaultsStore */
 	deleteBranchOnRemove: boolean | null;
 	/** null = inherit from repoDefaultsStore */
 	autoArchiveMerged: boolean | null;
@@ -78,6 +80,7 @@ export interface EffectiveRepoSettings {
 	terminalMetaHotkeys: boolean;
 	worktreeStorage: WorktreeStorage;
 	promptOnCreate: boolean;
+	promptOnWorktreeSwitch: boolean;
 	deleteBranchOnRemove: boolean;
 	autoArchiveMerged: boolean;
 	orphanCleanup: OrphanCleanup;
@@ -106,6 +109,7 @@ const OVERRIDABLE_NULL_DEFAULTS: Pick<
 	| "terminalMetaHotkeys"
 	| "worktreeStorage"
 	| "promptOnCreate"
+	| "promptOnWorktreeSwitch"
 	| "deleteBranchOnRemove"
 	| "autoArchiveMerged"
 	| "orphanCleanup"
@@ -127,6 +131,7 @@ const OVERRIDABLE_NULL_DEFAULTS: Pick<
 	terminalMetaHotkeys: null,
 	worktreeStorage: null,
 	promptOnCreate: null,
+	promptOnWorktreeSwitch: null,
 	deleteBranchOnRemove: null,
 	autoArchiveMerged: null,
 	orphanCleanup: null,
@@ -214,6 +219,7 @@ function createRepoSettingsStore() {
 		worktreeStorage: (s, local) =>
 			s.worktreeStorage ?? local()?.worktree_storage ?? repoDefaultsStore.state.worktreeStorage,
 		promptOnCreate: (s) => s.promptOnCreate ?? repoDefaultsStore.state.promptOnCreate,
+		promptOnWorktreeSwitch: (s) => s.promptOnWorktreeSwitch ?? repoDefaultsStore.state.promptOnWorktreeSwitch,
 		deleteBranchOnRemove: (s, local) =>
 			s.deleteBranchOnRemove ?? local()?.delete_branch_on_remove ?? repoDefaultsStore.state.deleteBranchOnRemove,
 		autoArchiveMerged: (s, local) =>
@@ -316,6 +322,7 @@ function createRepoSettingsStore() {
 				terminalMetaHotkeys: resolvers.terminalMetaHotkeys(settings, local),
 				worktreeStorage: resolvers.worktreeStorage(settings, local),
 				promptOnCreate: resolvers.promptOnCreate(settings, local),
+				promptOnWorktreeSwitch: resolvers.promptOnWorktreeSwitch(settings, local),
 				deleteBranchOnRemove: resolvers.deleteBranchOnRemove(settings, local),
 				autoArchiveMerged: resolvers.autoArchiveMerged(settings, local),
 				orphanCleanup: resolvers.orphanCleanup(settings, local),


### PR DESCRIPTION
## Summary

The "Switch to new worktree?" confirm is raised by the `worktree-created` event, and only two places emit it: the MCP `repo worktree_create` tool (`mcp_http/session.rs`) and the HTTP worktree route (`mcp_http/worktree_routes.rs`). The in-app "+" button never does. So the dialog is, in practice, exclusive to worktrees an agent or a remote client created, which is exactly the case where nobody is at the keyboard to answer it.

During a parallel-agent run an orchestrator creates a worktree every few minutes, and each one raises a modal the agent pane never wants to accept, then sits there until its ten-second auto-cancel expires. This adds `promptOnWorktreeSwitch` so that confirm can be turned off. It defaults to on, so nothing changes until a user turns it off, and the sidebar row plus the Activity entry for the new worktree are added either way.

It is implemented exactly like `promptOnCreate`: a repo default with a nullable per-repo override, resolved through the effective-settings chain, injected into the hook as a dep the way `App.tsx` already injects `getPromptOnCreate` into `useGitOperations`. Like `promptOnCreate`, it is user-specific and deliberately stays out of `.tuic.json`.

## Changes

- `src/stores/repoDefaults.ts` — `promptOnWorktreeSwitch` field (initial value `true`), load and save mapping for `prompt_on_worktree_switch`, and a setter.
- `src/stores/repoSettings.ts` — nullable per-repo field, overridable-key union entry, and a resolver falling back to the global default.
- `src/hooks/useWorktreeSwitchPrompt.ts` — optional `getPromptOnWorktreeSwitch` dep; `promptForCreatedWorktree` returns early when it resolves false. The gate is inside `promptForCreatedWorktree`, not the listener, so `setBranch` and `activityStore.addItem` still run.
- `src/App.tsx` — wires the dep from the effective repo settings, mirroring the `getPromptOnCreate` block just above.
- `src/components/SettingsPanel/tabs/GitHubTab.tsx` — global toggle under Worktree Defaults, next to "Prompt for branch name during creation".
- `src/components/SettingsPanel/tabs/RepoWorktreeTab.tsx` — per-repo override with the same `effectiveBool` + "(Global Default)" inherit pattern.
- `src-tauri/src/config.rs` — `prompt_on_worktree_switch` on `RepoDefaultsConfig` (`#[serde(default = "default_true")]`, so existing `repo-defaults.json` files still load and keep today's behavior) and as `Option<bool>` on `RepoSettingsEntry`, plus its arm in `has_custom_settings()`.
- `CHANGELOG.md`, `docs/user-guide/settings.md` — Unreleased entry, and the new field added to the list of user-specific settings excluded from `.tuic.json`.

## Test plan

Automated:

- `src/__tests__/hooks/worktreeSwitchPrompt.test.ts` — two new cases: the confirm and `handleBranchSelect` are never called when the setting resolves false, and the dialog still appears when it resolves true. They use the same `vi.fn()` confirm stub as the three existing cases.
- `src/__tests__/stores/repoDefaults.test.ts` — three new cases: hydrate defaults the field to `true` when the key is absent, hydrate honors an explicit `false`, and the setter persists `prompt_on_worktree_switch: false`. The existing "save includes full config with all fields" exact-match assertion also now covers the key.
- `src/__tests__/components/RepoSettingsPanel.test.tsx` — the mock `RepoSettings` gained the new field.
- `src-tauri/src/config.rs` — the four existing worktree-field round-trip and serde-default tests gained assertions for the new field (including "old config without the field loads as `true`"), plus `has_custom_settings_true_when_prompt_on_worktree_switch_set`.

Results:

- `tsc --noEmit`: clean.
- `vitest run`: 5477 passed, 364 files passed. One suite, `src/__tests__/plugins/buildCleaner.test.ts`, fails to collect in my checkout because the `plugins/` submodule is not initialized there. It is unrelated to this change and fails identically on a clean tree.
- `biome check src/`: 865 files, no diagnostics.
- `cargo test` / `cargo clippy`: **not run.** No Rust toolchain is installed on this machine. The Rust change is four field additions and one new test, and the exhaustive struct literals in `config.rs` tests were updated by hand, but please treat the Rust side as compiler-unverified. Note also that `make dev` does not hot-reload Rust, so the new default needs a restart to load.

Manual:

1. Settings, GitHub tab, Worktree Defaults: the new "Ask to switch after creating a worktree" toggle sits under "Prompt for branch name during creation" and is on.
2. Have an MCP client call `repo worktree_create`. The "Switch to new worktree?" dialog appears, as today.
3. Turn the toggle off and repeat. No dialog. The worktree still appears in the sidebar and in the Activity list.
4. Settings, a repository's Worktree tab: the same toggle shows "(Global Default)" until it is clicked, after which that repo overrides the global value in both directions.

## Follow-up idea

An alternative I deliberately did not build here: skip the prompt automatically for worktrees created over MCP, while still asking for ones created by a human over the HTTP API. That needs a source or origin field added to the `worktree-created` payload at both emit sites and threaded through `state.rs` and the SSE bridge, which is a separate change to the event contract rather than a setting. The setting is also the more useful of the two if you sometimes do want to be asked, so I would rather land this first and let you decide whether the automatic case is worth the payload change.

Generated with Claude Code
